### PR TITLE
Compact the README; add an Overview chapter to the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ docs/build/
 docs/source/api/
 docs/source/notebooks/
 docs/source/jupyter_execute/
+docs/source/_media/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ as several tools at once:
 All four are the same underlying object — an *automatic presentation* — viewed
 from different angles.
 
+> 📖 **[Documentation & guided tour → fariedabuzaid.github.io/AutStr](https://fariedabuzaid.github.io/AutStr/)**
+> — a full [overview chapter](https://fariedabuzaid.github.io/AutStr/overview.html),
+> the API reference, and executable notebooks for every part of the library. This
+> README is the short version.
+
 ---
 
 ## Quick start
@@ -40,458 +45,120 @@ from different angles.
 pip install autstr
 ```
 
-The friendliest entry point is the arithmetic package, which presents the
-integers ℤ with addition, order, and base-2 weak divisibility.
+The friendliest entry point is the arithmetic package: relations over the
+integers are first-class, exactly-represented **infinite** objects that you
+combine with relational algebra.
 
 ```python
 from autstr.arithmetic import VariableETerm as Var
 
-x, y = Var('x'), Var('y')
+x, y, z = Var('x'), Var('y'), Var('z')
 
-# A relation is defined by comparing linear terms. This is the *infinite* set
-# of all integer pairs (x, y) with x + y + 3 < 2x:
-R = (x + y + 3).lt(2 * x)
+R = (x + y + 3).lt(2 * x)     # the infinite set { (x, y) : x + y + 3 < 2x }
+R.isempty()                   # False
+(0, 4) in R                   # False   — membership test
 
-R.isempty()      # False   — is the relation empty?
-R.isfinite()     # False   — does it have finitely many solutions?
-(0, 4) in R      # False   — membership test
-
-for solution, _ in zip(R, range(5)):   # enumerate solutions, smallest-first
-    print(solution)                     # (1, -3), (2, -2), (2, -3), ...
+band = (x + y).eq(z) & z.gt(0) & z.lt(3)   # x + y = z  ∧  0 < z < 3
+solutions = band.drop(['z'])               # project z away (an ∃ quantifier)
+for s, _ in zip(solutions, range(3)):      # enumerate lazily, smallest-first
+    print(s)                               # (0, 1), (1, 0), (1, 1), ...
 ```
 
-Every relation is a first-class, exactly-represented infinite object you can
-combine with **relational algebra**:
-
-```python
-z = Var('z')
-E = (x + y).eq(z)                 # the ternary relation  x + y = z
-band = E & z.gt(0) & z.lt(3)      # intersect with  0 < z < 3
-proj = band.drop(['z'])           # project away z  (an existential quantifier)
-complement = ~proj                # negation
-inf = E.exinf('x')                # { (y,z) | infinitely many x with x+y=z }
-```
-
-and a base-2 **weak divisibility** predicate that makes definitions like the
-powers of two a one-liner:
-
-```python
-powers_of_two = x | x       # { 2^n : n >= 0 }
-(1024,) in powers_of_two    # True
-(3,) in powers_of_two       # False
-```
+Nothing is materialized until you iterate; `& | ~` are exact operations on
+infinite sets.
 
 ---
 
-## ⚙️ Highlight: synthesizing linear-time algorithms
+## Structures and classes
 
-Write *what* you want as a logical formula; AutStr compiles it — once — into a
-finite automaton that decides it. On structurally restricted inputs (bounded
-tree-depth, bounded pathwidth, …) that automaton is a **linear-time algorithm**,
-even for properties that are NP-hard in general.
+AutStr represents two kinds of thing, and the distinction shapes everything you
+do with it.
 
-The [`autstr.graphs`](autstr/graphs.py) package presents *all graphs of tree-depth
-≤ d* as one **uniformly automatic class** (see below). A graph is encoded as an
-*advice word*; deciding an MSO property means running that word through the query
-automaton — a single linear pass.
+### A structure — one infinite object
+
+(ℤ, +, <), the rationals (ℚ, +) = ℤ[1/p], Skolem arithmetic (ℕ, ·). An
+`AutomaticPresentation` bundles automata for a structure's domain and relations.
+Because the first-order theory of an automatic structure is **decidable**,
+`check` always terminates with a definite answer — a theorem prover for the
+fragment these structures capture — and `evaluate` returns the automaton of *all*
+satisfying assignments, which you can enumerate or reuse.
+
+```python
+from autstr.buildin.presentations import BuechiArithmeticZ
+
+Z = BuechiArithmeticZ()                          # (ℤ, +, <, |) as automata
+Z.check('all x.(exists y.(A(x,y,x)))')           # ∀x ∃y: x+y=x   — True
+Z.check('exists x.(all y.(Lt(x,y)))')            # a least integer? — False
+```
+
+### A class — a whole family at once
+
+A **uniformly automatic class** presents an entire *family* of finite structures
+by giving every automaton one extra tape that reads an **advice string**
+synchronously with the elements; fixing the advice instantiates one member. A
+query is compiled **once for the class** and then decides *any* member by running
+its advice word through the resulting automaton — a single linear pass.
+
+On classes of bounded width this is a constructive, streaming form of
+**Courcelle's theorem**: a declarative MSO specification becomes a **linear-time
+algorithm**, even for properties that are NP-hard in general.
 
 ```python
 import networkx as nx
 from autstr.graphs import TreeDepthClass, TreeDepthGraph
 
-cls = TreeDepthClass(3)
+cls = TreeDepthClass(3)                           # ALL graphs of tree-depth ≤ 3
+bipartite = ('exists c.(all x.(all y.((not E(x,y)) or '   # MSO, compiled once
+             '((Subset(x,c) and (not Subset(y,c))) or '
+             '((not Subset(x,c)) and Subset(y,c))))))')
 
-# Bipartiteness, as a monadic second-order formula. Compiled ONCE for the whole
-# class into a 6-state automaton:
-bipartite, _ = cls.evaluate(
-    'exists c.(all x.(all y.((not E(x,y)) or '
-    '((Subset(x,c) and (not Subset(y,c))) or '
-    '((not Subset(x,c)) and Subset(y,c))))))')
-
-triangle = TreeDepthGraph.from_networkx(nx.cycle_graph(3))
-bipartite.accepts([(s,) for s in cls.advice(triangle)])   # False — in microseconds
+cls.check(bipartite, TreeDepthGraph.from_networkx(nx.cycle_graph(3)))  # triangle → False, in µs
+cls.check(bipartite, TreeDepthGraph.from_networkx(nx.path_graph(6)))   # path → True
 ```
 
-**This scales.** Deciding the property on a graph is linear in its size, and the
-work batches beautifully (optionally on a GPU via the JAX backend). Measured on a
-laptop CPU (full details and reproduction in [`benchmarks/`](benchmarks/)):
+Deciding the property on a member is linear in its size and batches beautifully
+(optionally on a GPU via the JAX backend) — measured, a through-the-origin
+R² = 1.0000 across three orders of magnitude, ~90 million vertices / second in
+batch:
 
 ![Linear-time MSO query evaluation](benchmarks/runtime_curves.svg)
 
-- **Perfectly linear** decision time — a through-the-origin fit of R² = 1.0000
-  across three orders of magnitude; the JAX backend decides a million-vertex graph
-  in ~20 ms per query.
-- **Batched evaluation** classifies tens of thousands of graphs at once at
-  **~90 million vertices / second** — about **190×** a naive per-graph loop.
-- **3-colourability** — NP-complete in general — becomes a linear-time decision
-  here (its automaton is a heavier one-time compile; see the benchmark notes).
-
-The benchmark suite covers four different classes — tree-depth and pathwidth
-graphs, finite abelian groups, and extraspecial p-groups — each showing the same
-linear scaling. This is the practical payoff of the theory: **a declarative
-specification becomes an optimal streaming algorithm.**
-
-### Programming with infinite sets
-
-The flip side of algorithm *synthesis* is algorithm *design*: because relations
-are first-class infinite objects, you can write algorithms that manipulate them
-directly. Here is the Sieve of Eratosthenes running over the **actual infinite
-set** of integers — no bound, no array:
-
-```python
-def infinite_sieve(steps):
-    candidates = x.gt(1)                          # the infinite set {2, 3, 4, ...}
-    primes = []
-    for _ in range(steps):
-        for (p,) in candidates:                   # candidates enumerate smallest-first
-            primes.append(p); break               # ... so this is the next prime
-        multiples = (x.eq(primes[-1] * Var('y'))).drop(['y'])
-        candidates = candidates & ~multiples      # remove its multiples, symbolically
-    return primes, candidates
-
-primes, remaining = infinite_sieve(4)
-# primes    == [2, 3, 5, 7]
-# remaining  is the infinite set enumerating 11, 13, 17, 19, 23, 29, ...
-```
-
-Each `candidates & ~multiples` is an exact operation on infinite sets; nothing is
-materialized until you iterate. It is a conceptual tool for reasoning about and
-verifying infinite-state computations, not a fast primality test — but it shows
-how naturally infinite structures become ordinary Python values.
-
 ---
 
-## ⊢ Decision procedure & theorem prover
+## What's implemented
 
-An [`AutomaticPresentation`](autstr/presentations.py) bundles automata for a
-domain and its relations, and decides first-order statements about the presented
-structure:
+**Structures** — single automatic presentations:
 
-```python
-from autstr.buildin.presentations import BuechiArithmeticZ
+| package | structures |
+|---------|------------|
+| `autstr.arithmetic`, `autstr.buildin` | Presburger and Büchi arithmetic (ℤ, +, <, \|₂), Skolem arithmetic (ℕ, ·), the MSO0 finite-powerset structure |
+| `autstr.algebra` | the localizations **ℤ[1/p]**, finite **Boolean algebras** |
 
-Z = BuechiArithmeticZ()          # (ℤ, +, <, |) as automata
-
-Z.check('all x.(exists y.(A(x,y,x)))')          # ∀x ∃y: x+y=x   — True
-Z.check('exists x.(all y.(Lt(x,y)))')           # a least integer? — False
-```
-
-Because the first-order theory of an automatic structure is decidable, `check`
-always terminates with a definite answer — a theorem prover for the fragment of
-mathematics these structures capture. `evaluate` goes further and returns the
-automaton of *all* satisfying assignments, which you can enumerate or reuse.
-
----
-
-## 🧮 Computer algebra over infinite domains
-
-Structures need not be finitely generated. The localizations **ℤ[1/p]** — the
-rationals whose denominator is a power of p — are infinite, non-finitely-generated
-groups, yet each has an exact automatic presentation:
-
-```python
-from autstr.algebra import z1p_localization
-
-z2 = z1p_localization(2)                       # (ℤ[1/2], +)
-
-x = z2.from_fraction(1, 2)
-y = z2.from_fraction(3, 4)
-z2.check('A(x,y,z)', x=x, y=y, z=z2.add(x, y))                    # 1/2 + 3/4 = 5/4 — True
-z2.check('all x.(exists y.(A(y,y,x)))')                           # 2-divisible?    — True
-z2.check('all x.(exists y.(exists w.(A(y,y,w) and A(w,y,x))))')   # 3-divisible?    — False
-```
-
-The first-order divisibility theory even *distinguishes* the localizations: every
-element of ℤ[1/2] is 2-divisible but not 3-divisible, and vice versa for ℤ[1/3].
-
----
-
-## 🔬 Uniformly automatic classes: one automaton for a whole family
-
-The centrepiece of version 2. A **uniformly automatic class** presents not one
-structure but an entire *family*, by giving every automaton one extra tape that
-reads an **advice string** synchronously with the elements. Fixing the advice
-instantiates one member; a query is compiled once for the class and then decides
-any member by running its advice word through the resulting automaton.
-
-`autstr.graphs`, `autstr.algebra`, and `autstr.groups` ship ready-made classes:
-
-```python
-# Finite abelian groups — advice is the cyclic decomposition
-from autstr.groups import FiniteAbelianGroups
-ab = FiniteAbelianGroups()
-ab.check('A(x,y,z)', [2, 3], x=(1, 1), y=(1, 2), z=(0, 0))   # (1,1)+(1,2)=(0,0) in Z2⊕Z3
-
-# Non-abelian groups — dihedral, quaternion, semidihedral, modular, ...
-from autstr.groups import IndexTwoCyclicGroups
-G = IndexTwoCyclicGroups()
-G.check('M(x,y,z)', G.dicyclic(4), x=(0, 1), y=(1, 0), z=(1, 1))   # i·j = k in Q₈
-
-# Extraspecial p-groups — nilpotency class 2, order p^(1+2n)
-from autstr.groups import ExtraspecialGroups
-H = ExtraspecialGroups(3)
-H.check('Cen(x)', 2, x=(1, (0, 0), (0, 0)))                        # central element
-```
-
-Built-in classes include:
+**Classes** — one automaton for a whole family, indexed by advice:
 
 | package | classes | signature |
 |---------|---------|-----------|
-| `autstr.graphs`  | bounded **tree-depth**, bounded **pathwidth** | full MSO over vertex sets (`Sing`, `Subset`, `E`) |
-| `autstr.algebra` | finite **Boolean algebras**, **ℤ[1/p]** | `Meet`/`Join`/`Compl`/`Leq`/`Atom`; `+` |
-| `autstr.groups`  | finite **abelian** groups, **index-≤2 cyclic** groups (dihedral, quaternion, semidihedral, modular), **extraspecial** p-groups, class-2 groups of bounded **linear rank-width** (over F_p or ℤ/pᵈ) | `+`; multiplication `M` |
-| `autstr.tree_graphs` | bounded **tree-width**, bounded **clique-width**, bounded **rank-width** | full MSO over vertex sets (`Sing`, `Subset`, `E`) |
-| `autstr.tree_groups` | **tree-indexed extraspecial** p-groups, class-2 groups of bounded **rank-width** (tree layouts, over F_p or ℤ/pᵈ) | multiplication `M` |
-| `autstr.cocycle_groups` | **distributed-center** class-2 groups of tensor cut-rank 1 (claim-and-verify microcode) | multiplication `M` |
+| `autstr.graphs`, `autstr.tree_graphs` | bounded **tree-depth**, **pathwidth**, **tree-width**, **clique-width**, **rank-width** graphs | full MSO over vertex sets (`Sing`, `Subset`, `E`) |
+| `autstr.groups`, `autstr.tree_groups` | finite **abelian** groups, **index-≤2 cyclic** groups (dihedral, quaternion, semidihedral, modular), **extraspecial** p-groups, class-2 groups of bounded **rank-width** (over F_p or ℤ/pᵈ) | group multiplication `M` |
+| `autstr.cocycle_groups` | **distributed-center** class-2 groups of bounded rank-width | multiplication `M` |
 
-The generic machinery in [`autstr.uniform`](autstr/uniform.py) turns *any*
-advice-indexed family of automata into a class with relativized query evaluation,
-sentence checking, member instantiation (`get_structure`), and a first-order
-`define` for bootstrapping complex relations from primitives.
+Three capabilities cut across all of these — each with its own chapter in the
+[documentation](https://fariedabuzaid.github.io/AutStr/overview.html):
 
-The same machinery runs over **trees** rather than words. Where an automatic
-presentation encodes elements as strings and a word automaton reads them, a
-*tree-automatic* presentation encodes them as finite trees read by a bottom-up
-tree automaton — which is exactly the step from Büchi's theorem to Rabin's.
-[`autstr.tree_uniform`](autstr/tree_uniform.py) hosts the classes whose advice
-is naturally a tree: a tree decomposition (bounded tree-width) or a
-k-expression (bounded clique-width), and Skolem arithmetic (ℕ, ·) in
-[`autstr.buildin.tree_presentations`](autstr/buildin/tree_presentations.py),
-where a number is the tree of its prime exponents.
+- **Composition** (`autstr.composition`) — disjoint union and direct products of
+  structures, and union and finite-product closure of classes.
+- **Implicit evaluation** (`autstr.implicit`) — `check_implicit` /
+  `evaluate_implicit` decide formulas and compute satisfying sets *without
+  building a query automaton*, reaching members whose automata are far too large
+  to construct.
+- **Trees** (`autstr.tree_uniform`, `autstr.sparse_tree_automata`) — the same
+  programme over finite trees read by bottom-up tree automata, the step from
+  Büchi's theorem to Rabin's.
 
-The showcase notebooks in [`notebooks/`](notebooks/) walk through all of it, one
-per area — [`arithmetic_and_algebra.ipynb`](notebooks/arithmetic_and_algebra.ipynb),
-[`graphs.ipynb`](notebooks/graphs.ipynb), [`groups.ipynb`](notebooks/groups.ipynb),
-[`composition.ipynb`](notebooks/composition.ipynb) and
-[`implicit_evaluation.ipynb`](notebooks/implicit_evaluation.ipynb). They are stored
-output-free and executed as part of the
-[documentation build](https://fariedabuzaid.github.io/AutStr/), where they appear
-fully rendered.
-
----
-
-## 🧩 Composing presentations
-
-Automatic structures over a shared signature are closed under disjoint union and
-direct products; uniformly automatic classes of **finite** structures are closed under union and under
-taking all finite direct products of their members. `autstr.composition` builds
-the new presentation for you.
-
-```python
-from autstr.composition import (
-    class_union, direct_product_closure, blocks, tagged_advice,
-)
-from autstr.groups import ExtraspecialGroups, IndexTwoCyclicGroups
-from autstr.uniform import UniformlyAutomaticClass
-
-cyclic, extra = IndexTwoCyclicGroups(), ExtraspecialGroups(3)
-
-def reduct(uniform):                     # the signature the two classes share
-    return UniformlyAutomaticClass(
-        {'U': uniform.class_automata['U'], 'M': uniform.class_automata['M']})
-
-# Members of either family ...
-both = class_union(reduct(cyclic.cls), reduct(extra.cls))
-# ... and every finite direct product of them.
-groups = direct_product_closure(both)
-
-z4 = tagged_advice(cyclic.cyclic(4), '<l>')          # Z4, abelian
-heis = tagged_advice(extra.advice(1), '<r>')         # extraspecial 3^(1+2)
-
-abelian = 'all x.(all y.(all z.(M(x,y,z) -> M(y,x,z))))'
-groups.check(abelian, blocks(z4, z4))       # True  — Z4 × Z4
-groups.check(abelian, blocks(z4, heis))     # False — one nonabelian factor
-```
-
-| operation | on | construction |
-|-----------|----|--------------|
-| `disjoint_union(A, B)` | structures | tag each element with the side it came from |
-| `direct_product(A, B, kind='sync')` | structures | `R_A(a,a') ∧ R_B(b,b')` |
-| `direct_product(A, B, kind='async')` | structures | `(R_A(a,a') ∧ b=b') ∨ (R_B(b,b') ∧ a=a')` |
-| `class_union(C, D)` | classes | tag the *advice*, so the advice languages are disjoint |
-| `direct_product_closure(C)` | classes | advice `α₁\|…\|αₙ` presents `A_{α₁} × … × A_{αₙ}` |
-
-Two of these are worth a word. The **direct product** encodes a pair over the
-*pair alphabet*, where a letter carries one letter of each factor; each factor
-is then embedded by a variable renaming into its half of the bits, and the two
-products are Boolean combinations of the embeddings. That is affordable only
-because the pair alphabet has `|Σ_A|·|Σ_B|` letters but `bits_A + bits_B`
-variables — **letters multiply, bits add**, which is precisely what the decision
-diagrams buy.
-
-The **product closure** concatenates advices with a separator. Since an element
-of a finite member is never longer than its advice, the blocks line up across
-every tape, so a relation of the product is the original relation holding in
-every block — one automaton with **one extra state**, where an interleaved
-encoding would need one copy per component. `FiniteAbelianGroups` is this
-construction applied to the cyclic groups, and it predates the module.
-
-[`notebooks/composition.ipynb`](notebooks/composition.ipynb) walks through all
-five operations.
-
----
-
-## 📐 Bounded rank-width: groups and graphs from one linear algebra
-
-The width notions above bound how much *combinatorial* structure crosses a cut.
-Rank-width bounds the **linear-algebraic rank** of what crosses, and one body of
-machinery — saturated interface bases, streamed basis changes, a two-sided
-factorization of the sibling block ([`autstr.chain_ring`](autstr/chain_ring.py))
-— presents both groups and graphs of bounded rank-width uniformly.
-
-**Class-2 groups** ([`autstr.groups.CutRankGroups`](autstr/groups.py),
-[`autstr.tree_groups.CutRankTreeGroups`](autstr/tree_groups.py)): a member is a
-central extension of (ℤ/pᵈ)ⁿ by (ℤ/pᵈ)ᵏ given by commutator labels; the advice spells
-out, cut by cut, a rank-≤r factorization of the crossing block of the commutation
-form, and the multiplication automaton carries r linear functionals instead of
-the digits it has read. With `d = 1` this is the field F_p; with `d > 1` the
-center has exponent pᵈ and the width is measured over the *chain ring* ℤ/pᵈ,
-where the interfaces must be saturated (a valuation-carrying coefficient like 2
-over ℤ/4 still contributes rank). Bounded pathwidth, bounded vertex cover, the
-extraspecial matching and the complete graph are all special layouts; the tree
-class recovers the word class on spine layouts.
-[`autstr.cocycle_groups.CocycleRankWidthGroups`](autstr/cocycle_groups.py)
-generalizes further to *distributed* centers — central generators scattered
-through the layout — via a seven-register claim-and-verify automaton whose
-advice is microcode.
-
-When a flat advice alphabet would be astronomical (it grows like
-q^(r²+r+kr)), the classes switch to **factored letters**: one letter per ring
-entry of the factorization, streamed through an accumulator — the advice
-alphabet drops to q+1 letters, and width r ≥ 2 over ℤ/4 went from
-unrepresentable to an explicitly buildable automaton this way.
-
-**Graphs** ([`autstr.tree_graphs.RankWidthClass`](autstr/tree_graphs.py)): the
-advice is a rank decomposition annotated with the GF(2) factorization of its
-cuts; adjacency of two vertices is a bilinear form applied to their r-bit
-interface vectors at the node where their subtrees meet. Rank-width
-lower-bounds clique-width and stays bounded on dense graphs (cliques have
-rank-width 1), and the class answers MSO queries like every other graph class:
-
-```python
-from autstr.tree_graphs import RankWidthClass, RankWidthGraph
-
-rw = RankWidthClass(1)
-two_col = ('exists a.(all x.(all y.((not E(x,y)) or '
-           '((Subset(x,a) and (not Subset(y,a))) or '
-           '(Subset(y,a) and (not Subset(x,a)))))))')
-rw.check(two_col, RankWidthGraph.complete_bipartite(2, 3))   # True  (rank-width 1)
-rw.check(two_col, RankWidthGraph.clique(3))                  # False (odd cycle)
-```
-
----
-
-## ♾️ Implicit evaluation: members whose automata cannot be built
-
-For the heavy ring members the *base* multiplication automaton is already
-infeasible to construct — an O(|Σ|⁴) product over a huge advice alphabet. The
-[`autstr.implicit`](autstr/implicit.py) layer decides first-order formulas on
-such members anyway, by never building anything: Boolean connectives keep
-composite states and step the base automata on the fly, EXISTS is an
-on-the-fly powerset over the (tiny) element alphabet, NOT flips acceptance.
-Because the advice is fixed input, the cost is driven by quantifier
-alternation, not by alphabet size.
-
-```python
-from autstr.groups import CutRankGroups
-
-G = CutRankGroups(2, d=3)         # commutation forms over Z/8 — automata unbuildable
-advice = G.advice(3, G.clique_form(3))
-x = ((5,), (3, 1, 6))
-
-# model checking, implicitly:
-G.check_implicit('exists y.(M(x,y,u))', advice, x=x, u=G.identity(3))   # True
-
-# the satisfying SET, implicitly: exact count without enumeration, lazy iteration
-inv = G.evaluate_implicit('M(x,y,u)', advice, x=x, u=G.identity(3))
-len(inv)                          # 1 — the unique inverse
-next(iter(inv))['y']              # ... and here it is, as a (b, a) tuple
-```
-
-Every uniform class offers `check_implicit` (model checking) and
-`evaluate_implicit` (the satisfying assignments of a formula with open free
-variables, with the exact solution count computed by dynamic programming —
-no enumeration — and lazy iteration). `ImplicitClass` / `ImplicitTreeClass`
-package functional atoms and an element alphabet as a first-class *fully
-implicit* presentation: a uniformly automatic class given purely by
-transition functions, for members where even the presentation is too big to
-write down.
-
----
-
-## How it works
-
-An **automatic presentation** encodes a countable structure so that its domain is
-a regular language and each relation is recognized by a synchronous multi-tape
-automaton reading its arguments letter-by-letter in lockstep. The foundational
-fact is that this recognizability is *closed under first-order definability*:
-Boolean combinations correspond to product automata, and quantifiers to
-projection followed by determinization. Consequently the first-order theory of
-any automatic structure is **decidable**, and every definable relation is again
-automatic — which is exactly what makes the "algebra of infinite relations" above
-compute.
-
-**A concrete encoding.** In the arithmetic package an integer is written
-**sign-magnitude, least-significant bit first**: the first symbol is a sign bit
-(`0` for non-negative, `1` for negative), followed by the binary digits of the
-magnitude from the lowest bit upward, with `*` padding the shorter arguments of a
-multi-tape relation so all tapes advance in lockstep. Under this encoding a
-definable set is a genuinely small automaton — here, for instance, is the
-recognizer for the integers greater than 1 that are divisible by neither 2 nor 3,
-one of the infinite sets the [sieve](notebooks/arithmetic_and_algebra.ipynb)
-manipulates directly:
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/media/sieve_automaton-dark.png">
-    <img src="docs/media/sieve_automaton-light.png" width="720"
-         alt="A 9-state automaton recognizing the integers greater than 1 that are divisible by neither 2 nor 3">
-  </picture>
-</p>
-
-The start state consumes the sign bit; the remaining states scan the magnitude
-bits from least to most significant. Because "greater than 1" and "not divisible
-by 2 or 3" are both regular properties of that bit stream, a handful of states
-suffice — doubled circles are accepting, and `*` marks the padding that ends the
-word.
-
-**Advice and uniform classes.** Allowing the automata to read an additional
-fixed *advice* word widens the reach to structures like (ℚ, +) and, using a *set*
-of advices, to whole parameterized classes of finite structures. Deciding the
-first-order theory of a uniformly automatic class reduces to the monadic
-second-order theory of its advice language (Abu Zaid–Grädel–Reinhardt 2017;
-Abu Zaid 2018).
-
-**Trees.** The same programme runs over finite *trees* read by bottom-up tree
-automata rather than words read by word automata — the step from Büchi's theorem
-to Rabin's. A tree-automatic presentation buys structures that no string encoding
-reaches naturally, such as (ℕ, ·) with a number written as the tree of its prime
-exponents, and classes whose advice is inherently a tree: a tree decomposition
-(bounded tree-width) or a k-expression (bounded clique-width).
-
-**Why it is fast — and where it is hard.** Evaluating a *fixed* formula on a
-structure is one linear pass of its advice through the query automaton, so on any
-class of bounded width every fixed MSO property is decided in linear time — a
-constructive, streaming form of Courcelle's theorem. The cost lives entirely in
-*compiling* the automaton.
-
-A transition is not a `symbol -> target` table but a **decision diagram over the
-symbol's digits**, hash-consed and shared across states and automata
-([`autstr.mtbdd`](autstr/mtbdd.py)) — the representation MONA uses, for the same
-reason. A transition that ignores a tape never tests that tape's variables, so
-cylindrification is a variable renaming rather than a duplication of every row
-once per letter of every new tape, complementation touches no diagram at all, and
-the alphabet's *width* stops driving the cost. What remains is the subset
-explosion of determinizing an existential quantifier: element quantifiers are
-cheap, and *set* quantifiers (MSO proper) determinize over subsets of the
-intermediate automaton's states. Connectedness and bipartiteness compile in
-seconds; 3-colourability — the minimal NP-hard MSO query — is a genuinely large
-one-time compile. Once compiled, an automaton can be serialized (diagrams and
-all) and reused forever.
-
-Around the diagrams the engine is batched NumPy: frontier-batched constructions,
-hashed partition refinement, and a subset construction that runs in a collectable
-scratch store. JAX is an optional accelerator used only for bulk word processing.
+The [overview chapter](https://fariedabuzaid.github.io/AutStr/overview.html) and
+the executable notebooks in [`notebooks/`](notebooks/) work through all of it,
+one per area — arithmetic & algebra, graphs, groups, composition, and implicit
+evaluation.
 
 ---
 
@@ -564,7 +231,7 @@ mathematical direction and review kept firmly human.
     compile: an arity-5 relation over a 14-letter alphabet (14⁵ = 537 824 flat
     symbols) went from *infeasible* to 0.2 s; tree-depth-4 bipartiteness from
     17 s to 0.4 s. The test suite went from ~2 min to ~35 s.
- 
+
   - **composing presentations.** `autstr.composition`: disjoint union and
     synchronous/asynchronous direct products of automatic structures, union of
     uniformly automatic classes, and the direct-product closure of a class.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ as several tools at once:
 All four are the same underlying object — an *automatic presentation* — viewed
 from different angles.
 
-> 📖 **[Documentation & guided tour → fariedabuzaid.github.io/AutStr](https://fariedabuzaid.github.io/AutStr/)**
-> — a full [overview chapter](https://fariedabuzaid.github.io/AutStr/overview.html),
-> the API reference, and executable notebooks for every part of the library. This
-> README is the short version.
+> 📖 For a thorough introduction to the library, please consult the
+> **[Documentation](https://fariedabuzaid.github.io/AutStr/)**.
 
 ---
 
@@ -142,8 +140,7 @@ batch:
 | `autstr.groups`, `autstr.tree_groups` | finite **abelian** groups, **index-≤2 cyclic** groups (dihedral, quaternion, semidihedral, modular), **extraspecial** p-groups, class-2 groups of bounded **rank-width** (over F_p or ℤ/pᵈ) | group multiplication `M` |
 | `autstr.cocycle_groups` | **distributed-center** class-2 groups of bounded rank-width | multiplication `M` |
 
-Three capabilities cut across all of these — each with its own chapter in the
-[documentation](https://fariedabuzaid.github.io/AutStr/overview.html):
+Three capabilities cut across all of these:
 
 - **Composition** (`autstr.composition`) — disjoint union and direct products of
   structures, and union and finite-product closure of classes.
@@ -155,8 +152,7 @@ Three capabilities cut across all of these — each with its own chapter in the
   programme over finite trees read by bottom-up tree automata, the step from
   Büchi's theorem to Rabin's.
 
-The [overview chapter](https://fariedabuzaid.github.io/AutStr/overview.html) and
-the executable notebooks in [`notebooks/`](notebooks/) work through all of it,
+The executable notebooks in [`notebooks/`](notebooks/) work through all of it,
 one per area — arithmetic & algebra, graphs, groups, composition, and implicit
 evaluation.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,15 @@ _nb_dst.mkdir(exist_ok=True)
 for _nb in sorted((_here.parent.parent / 'notebooks').glob('*.ipynb')):
     shutil.copyfile(_nb, _nb_dst / _nb.name)
 
+# Copy the README media images into the source tree so overview.md can embed
+# them (the PNGs only; the history GIF is git-lfs and unused in the docs).
+_media_dst = _here / '_media'
+if _media_dst.exists():
+    shutil.rmtree(_media_dst)
+_media_dst.mkdir(exist_ok=True)
+for _img in sorted((_here.parent / 'media').glob('*.png')):
+    shutil.copyfile(_img, _media_dst / _img.name)
+
 nb_execution_mode = 'force'
 nb_execution_timeout = 900
 nb_execution_raise_on_error = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,10 +2,16 @@ AutStr: computing with infinite structures
 ==========================================
 
 AutStr represents infinite mathematical structures as finite automata and lets
-you query them with first-order and monadic second-order logic. See the
-`README <https://github.com/fariedabuzaid/AutStr>`_ for a tour. This site
-carries the API reference, generated from the docstrings, and the showcase
-notebooks — executed freshly on every documentation build.
+you query them with first-order and monadic second-order logic. Start with the
+**Overview** for a guided tour; the showcase notebooks — executed freshly on
+every documentation build — work through each area in depth, and the API
+reference is generated from the docstrings.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Guide
+
+   overview
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -1,0 +1,316 @@
+# Overview
+
+AutStr represents infinite mathematical structures as finite automata and decides
+first-order and monadic second-order questions about them. This chapter is the
+guided tour: it works through the two things the library represents — single
+**structures** and whole **classes** — the operations that combine them, the
+rank-width families, implicit evaluation, and finally how the machine works
+underneath. Every part has a matching executable notebook, linked as we go.
+
+The `README <https://github.com/fariedabuzaid/AutStr>`_ is the short version of
+this page; the API reference is generated from the docstrings and linked in the
+sidebar.
+
+## Decision procedure and theorem prover
+
+An `AutomaticPresentation` bundles automata for a domain and its relations, and
+decides first-order statements about the presented structure:
+
+```python
+from autstr.buildin.presentations import BuechiArithmeticZ
+
+Z = BuechiArithmeticZ()          # (ℤ, +, <, |) as automata
+
+Z.check('all x.(exists y.(A(x,y,x)))')          # ∀x ∃y: x+y=x   — True
+Z.check('exists x.(all y.(Lt(x,y)))')           # a least integer? — False
+```
+
+Because the first-order theory of an automatic structure is decidable, `check`
+always terminates with a definite answer — a theorem prover for the fragment of
+mathematics these structures capture. `evaluate` goes further and returns the
+automaton of *all* satisfying assignments, which you can enumerate or reuse. The
+{doc}`arithmetic & algebra notebook <notebooks/arithmetic_and_algebra>` walks
+through Presburger and Büchi arithmetic in full.
+
+## Computer algebra over infinite domains
+
+Structures need not be finitely generated. The localizations **ℤ[1/p]** — the
+rationals whose denominator is a power of p — are infinite,
+non-finitely-generated groups, yet each has an exact automatic presentation:
+
+```python
+from autstr.algebra import z1p_localization
+
+z2 = z1p_localization(2)                       # (ℤ[1/2], +)
+
+x = z2.from_fraction(1, 2)
+y = z2.from_fraction(3, 4)
+z2.check('A(x,y,z)', x=x, y=y, z=z2.add(x, y))                    # 1/2 + 3/4 = 5/4 — True
+z2.check('all x.(exists y.(A(y,y,x)))')                           # 2-divisible?    — True
+z2.check('all x.(exists y.(exists w.(A(y,y,w) and A(w,y,x))))')   # 3-divisible?    — False
+```
+
+The first-order divisibility theory even *distinguishes* the localizations: every
+element of ℤ[1/2] is 2-divisible but not 3-divisible, and vice versa for ℤ[1/3].
+
+## Uniformly automatic classes: one automaton for a whole family
+
+A **uniformly automatic class** presents not one structure but an entire *family*,
+by giving every automaton one extra tape that reads an **advice string**
+synchronously with the elements. Fixing the advice instantiates one member; a
+query is compiled once for the class and then decides any member by running its
+advice word through the resulting automaton.
+
+`autstr.graphs`, `autstr.algebra`, and `autstr.groups` ship ready-made classes:
+
+```python
+# Finite abelian groups — advice is the cyclic decomposition
+from autstr.groups import FiniteAbelianGroups
+ab = FiniteAbelianGroups()
+ab.check('A(x,y,z)', [2, 3], x=(1, 1), y=(1, 2), z=(0, 0))   # (1,1)+(1,2)=(0,0) in Z2⊕Z3
+
+# Non-abelian groups — dihedral, quaternion, semidihedral, modular, ...
+from autstr.groups import IndexTwoCyclicGroups
+G = IndexTwoCyclicGroups()
+G.check('M(x,y,z)', G.dicyclic(4), x=(0, 1), y=(1, 0), z=(1, 1))   # i·j = k in Q₈
+
+# Extraspecial p-groups — nilpotency class 2, order p^(1+2n)
+from autstr.groups import ExtraspecialGroups
+H = ExtraspecialGroups(3)
+H.check('M(x,y,z)', 2, x=(1, (0, 0), (0, 0)), y=(0, (1, 0), (0, 0)),
+        z=(1, (1, 0), (0, 0)))
+```
+
+The generic machinery in `autstr.uniform` turns *any* advice-indexed family of
+automata into a class with relativized query evaluation, sentence checking, member
+instantiation (`get_structure`), and a first-order `define` for bootstrapping
+complex relations from primitives.
+
+The same machinery runs over **trees** rather than words. Where an automatic
+presentation encodes elements as strings and a word automaton reads them, a
+*tree-automatic* presentation encodes them as finite trees read by a bottom-up
+tree automaton — exactly the step from Büchi's theorem to Rabin's.
+`autstr.tree_uniform` hosts the classes whose advice is naturally a tree: a tree
+decomposition (bounded tree-width) or a k-expression (bounded clique-width), and
+Skolem arithmetic (ℕ, ·) in `autstr.buildin.tree_presentations`, where a number
+is the tree of its prime exponents.
+
+The {doc}`graphs <notebooks/graphs>` and {doc}`groups <notebooks/groups>`
+notebooks build these classes and query them; the
+{doc}`arithmetic & algebra notebook <notebooks/arithmetic_and_algebra>` covers the
+Boolean algebras, ℤ[1/p], and the MSO0 finite-powerset structure.
+
+## Composing presentations
+
+Automatic structures over a shared signature are closed under disjoint union and
+direct products; uniformly automatic classes of **finite** structures are closed
+under union and under taking all finite direct products of their members.
+`autstr.composition` builds the new presentation for you.
+
+```python
+from autstr.composition import (
+    class_union, direct_product_closure, blocks, tagged_advice,
+)
+from autstr.groups import ExtraspecialGroups, IndexTwoCyclicGroups
+from autstr.uniform import UniformlyAutomaticClass
+
+cyclic, extra = IndexTwoCyclicGroups(), ExtraspecialGroups(3)
+
+def reduct(uniform):                     # the signature the two classes share
+    return UniformlyAutomaticClass(
+        {'U': uniform.class_automata['U'], 'M': uniform.class_automata['M']})
+
+# Members of either family ...
+both = class_union(reduct(cyclic.cls), reduct(extra.cls))
+# ... and every finite direct product of them.
+groups = direct_product_closure(both)
+
+z4 = tagged_advice(cyclic.cyclic(4), '<l>')          # Z4, abelian
+heis = tagged_advice(extra.advice(1), '<r>')         # extraspecial 3^(1+2)
+
+abelian = 'all x.(all y.(all z.(M(x,y,z) -> M(y,x,z))))'
+groups.check(abelian, blocks(z4, z4))       # True  — Z4 × Z4
+groups.check(abelian, blocks(z4, heis))     # False — one nonabelian factor
+```
+
+| operation | on | construction |
+|-----------|----|--------------|
+| `disjoint_union(A, B)` | structures | tag each element with the side it came from |
+| `direct_product(A, B, kind='sync')` | structures | `R_A(a,a') ∧ R_B(b,b')` |
+| `direct_product(A, B, kind='async')` | structures | `(R_A(a,a') ∧ b=b') ∨ (R_B(b,b') ∧ a=a')` |
+| `class_union(C, D)` | classes | tag the *advice*, so the advice languages are disjoint |
+| `direct_product_closure(C)` | classes | advice `α₁\|…\|αₙ` presents `A_{α₁} × … × A_{αₙ}` |
+
+Two of these are worth a word. The **direct product** encodes a pair over the
+*pair alphabet*, where a letter carries one letter of each factor; each factor is
+then embedded by a variable renaming into its half of the bits, and the two
+products are Boolean combinations of the embeddings. That is affordable only
+because the pair alphabet has `|Σ_A|·|Σ_B|` letters but `bits_A + bits_B`
+variables — **letters multiply, bits add**, which is precisely what the decision
+diagrams buy.
+
+The **product closure** concatenates advices with a separator. Since an element of
+a finite member is never longer than its advice, the blocks line up across every
+tape, so a relation of the product is the original relation holding in every block
+— one automaton with **one extra state**, where an interleaved encoding would need
+one copy per component. `FiniteAbelianGroups` is this construction applied to the
+cyclic groups, and it predates the module. The
+{doc}`composition notebook <notebooks/composition>` walks through all five
+operations.
+
+## Bounded rank-width: groups and graphs from one linear algebra
+
+The width notions above bound how much *combinatorial* structure crosses a cut.
+Rank-width bounds the **linear-algebraic rank** of what crosses, and one body of
+machinery — interface bases, streamed basis changes, and a two-sided factorization
+of the sibling block (`autstr.chain_ring`) — presents both groups and graphs of
+bounded rank-width uniformly.
+
+**Class-2 groups** (`autstr.groups.CutRankGroups`,
+`autstr.tree_groups.CutRankTreeGroups`): a member is a central extension of
+(ℤ/pᵈ)ⁿ by (ℤ/pᵈ)ᵏ given by commutator labels; the advice spells out, cut by cut, a
+rank-≤r factorization of the crossing block of the commutation form, and the
+multiplication automaton carries r linear functionals instead of the digits it has
+read. With `d = 1` this is the field F_p; with `d > 1` the center has exponent pᵈ
+and the width is measured over the *chain ring* ℤ/pᵈ. Bounded pathwidth, bounded
+vertex cover, the extraspecial matching and the complete graph are all special
+layouts; the tree class recovers the word class on spine layouts.
+`autstr.cocycle_groups.CocycleRankWidthGroups` generalizes further to *distributed*
+centers — central generators scattered through the layout — via a six-register
+protocol whose advice is microcode.
+
+When a flat advice alphabet would be astronomical (it grows like q^(r²+r+kr)), the
+classes switch to **factored letters**: one letter per ring entry of the
+factorization, streamed through an accumulator — the advice alphabet drops to q+1
+letters, and width r ≥ 2 over ℤ/4 goes from unrepresentable to explicitly
+buildable this way.
+
+**Graphs** (`autstr.tree_graphs.RankWidthClass`): the advice is a rank
+decomposition annotated with the GF(2) factorization of its cuts; adjacency of two
+vertices is a bilinear form applied to their r-bit interface vectors at the node
+where their subtrees meet. Rank-width lower-bounds clique-width and stays bounded
+on dense graphs (cliques have rank-width 1), and the class answers MSO queries like
+every other graph class:
+
+```python
+from autstr.tree_graphs import RankWidthClass, RankWidthGraph
+
+rw = RankWidthClass(1)
+two_col = ('exists a.(all x.(all y.((not E(x,y)) or '
+           '((Subset(x,a) and (not Subset(y,a))) or '
+           '(Subset(y,a) and (not Subset(x,a)))))))')
+rw.check(two_col, RankWidthGraph.complete_bipartite(2, 3))   # True  (rank-width 1)
+rw.check(two_col, RankWidthGraph.clique(3))                  # False (odd cycle)
+```
+
+The bounded-rank-width groups appear in the {doc}`groups notebook <notebooks/groups>`
+and the graphs in the {doc}`graphs notebook <notebooks/graphs>`.
+
+## Implicit evaluation: members whose automata cannot be built
+
+For the heavy ring members the *base* multiplication automaton is already
+infeasible to construct — an O(|Σ|⁴) product over a huge advice alphabet. The
+`autstr.implicit` layer decides first-order formulas on such members anyway, by
+never building anything: Boolean connectives keep composite states and step the
+base automata on the fly, `exists` is an on-the-fly powerset over the (tiny)
+element alphabet, `not` flips acceptance. Because the advice is fixed input, the
+cost is driven by quantifier alternation, not by alphabet size.
+
+```python
+from autstr.groups import CutRankGroups
+
+G = CutRankGroups(2, d=3)         # commutation forms over Z/8 — automata unbuildable
+advice = G.advice(3, G.clique_form(3))
+x = ((5,), (3, 1, 6))
+
+# model checking, implicitly:
+G.check_implicit('exists y.(M(x,y,u))', advice, x=x, u=G.identity(3))   # True
+
+# the satisfying SET, implicitly: exact count without enumeration, lazy iteration
+inv = G.evaluate_implicit('M(x,y,u)', advice, x=x, u=G.identity(3))
+len(inv)                          # 1 — the unique inverse
+next(iter(inv))['y']              # ... and here it is, as a (b, a) tuple
+```
+
+Every uniform class offers `check_implicit` (model checking) and `evaluate_implicit`
+(the satisfying assignments of a formula with open free variables, with the exact
+solution count computed by dynamic programming — no enumeration — and lazy
+iteration). `ImplicitClass` / `ImplicitTreeClass` package functional atoms and an
+element alphabet as a first-class *fully implicit* presentation. The
+{doc}`implicit-evaluation notebook <notebooks/implicit_evaluation>` also times the
+implicit path against a compiled one.
+
+## How it works
+
+An **automatic presentation** encodes a countable structure so that its domain is a
+regular language and each relation is recognized by a synchronous multi-tape
+automaton reading its arguments letter-by-letter in lockstep. The foundational fact
+is that this recognizability is *closed under first-order definability*: Boolean
+combinations correspond to product automata, and quantifiers to projection followed
+by determinization. Consequently the first-order theory of any automatic structure
+is **decidable**, and every definable relation is again automatic.
+
+### A concrete encoding
+
+In the arithmetic package an integer is written **sign-magnitude, least-significant
+bit first**: the first symbol is a sign bit (`0` for non-negative, `1` for
+negative), followed by the binary digits of the magnitude from the lowest bit
+upward, with `*` padding the shorter arguments of a multi-tape relation so all
+tapes advance in lockstep. Under this encoding a definable set is a genuinely small
+automaton — here, for instance, is the recognizer for the integers greater than 1
+that are divisible by neither 2 nor 3:
+
+```{image} _media/sieve_automaton-light.png
+:alt: A 9-state automaton recognizing the integers greater than 1 divisible by neither 2 nor 3
+:width: 760px
+:align: center
+:class: only-light
+```
+
+```{image} _media/sieve_automaton-dark.png
+:alt: A 9-state automaton recognizing the integers greater than 1 divisible by neither 2 nor 3
+:width: 760px
+:align: center
+:class: only-dark
+```
+
+The start state consumes the sign bit; the remaining states scan the magnitude bits
+from least to most significant. Because "greater than 1" and "not divisible by 2 or
+3" are both regular properties of that bit stream, a handful of states suffice —
+doubled circles are accepting, and `*` marks the padding that ends the word.
+
+### Advice and trees
+
+Allowing the automata to read an additional fixed *advice* word widens the reach to
+structures like (ℚ, +) and, using a *set* of advices, to whole parameterized classes
+of finite structures. Deciding the first-order theory of a uniformly automatic class
+reduces to the monadic second-order theory of its advice language (Abu
+Zaid–Grädel–Reinhardt 2017; Abu Zaid 2018). The same programme runs over finite
+*trees* read by bottom-up tree automata, which reaches structures no string encoding
+captures naturally — (ℕ, ·) with a number written as the tree of its prime
+exponents, and classes whose advice is inherently a tree.
+
+### Why it is fast — and where it is hard
+
+Evaluating a *fixed* formula on a structure is one linear pass of its advice through
+the query automaton, so on any class of bounded width every fixed MSO property is
+decided in linear time — a constructive, streaming form of Courcelle's theorem. The
+cost lives entirely in *compiling* the automaton.
+
+A transition is not a `symbol -> target` table but a **decision diagram over the
+symbol's digits**, hash-consed and shared across states and automata
+(`autstr.mtbdd`) — the representation MONA uses, for the same reason. A transition
+that ignores a tape never tests that tape's variables, so cylindrification is a
+variable renaming rather than a duplication of every row once per letter of every
+new tape, complementation touches no diagram at all, and the alphabet's *width*
+stops driving the cost. What remains is the subset explosion of determinizing an
+existential quantifier: element quantifiers are cheap, and *set* quantifiers (MSO
+proper) determinize over subsets of the intermediate automaton's states.
+Connectedness and bipartiteness compile in seconds; 3-colourability — the minimal
+NP-hard MSO query — is a genuinely large one-time compile. Once compiled, an
+automaton can be serialized (diagrams and all) and reused forever.
+
+Around the diagrams the engine is batched NumPy: frontier-batched constructions,
+hashed partition refinement, and a subset construction that runs in a collectable
+scratch store. JAX is an optional accelerator used only for bulk word processing.
+```


### PR DESCRIPTION
The README had grown a long per-class middle that a first-time visitor is unlikely to read in full. This compresses it to what earns a landing page and moves the depth into the documentation.

**README now keeps** the motivational overview, minimal usage examples, the **structure-vs-class** distinction and its algorithmic use, a compact table of the implemented **structures and classes**, the changelog animation, and the references — and links to the documentation up front.

**New `docs/source/overview.md`** is the guided tour that used to live in the README middle: decision procedure, computer algebra over ℤ[1/p], uniform classes, composition, bounded rank-width, implicit evaluation, and *how it works* (the integer encoding and the automaton diagram). Wired in as the first entry of the docs, with theme-aware images (`only-light`/`only-dark`) and `{doc}` cross-links to the notebooks.

Verified with a full local `sphinx-build -W` (no warnings; overview + all notebooks build, images and cross-refs resolve); the README code examples were run to confirm their outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)