### PR TITLE
Tier I infinite structures: ordinals, the regular tree, TM configuration graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ batch:
 |---------|------------|
 | `autstr.arithmetic`, `autstr.buildin` | Presburger and Büchi arithmetic (ℤ, +, <, \|₂), Skolem arithmetic (ℕ, ·), the MSO0 finite-powerset structure |
 | `autstr.algebra` | the localizations **ℤ[1/p]**, finite **Boolean algebras** |
+| `autstr.infinite_graphs`, `autstr.ordinals`, `autstr.turing` | the **integer grid** ℤⁿ, the **regular tree** T_k, the **ordinals** below ω^ω, **Turing-machine configuration graphs** |
 
 **Classes** — one automaton for a whole family, indexed by advice:
 
@@ -140,10 +141,16 @@ batch:
 | `autstr.groups`, `autstr.tree_groups` | finite **abelian** groups, **index-≤2 cyclic** groups (dihedral, quaternion, semidihedral, modular), **extraspecial** p-groups, class-2 groups of bounded **rank-width** (over F_p or ℤ/pᵈ) | group multiplication `M` |
 | `autstr.cocycle_groups` | **distributed-center** class-2 groups of bounded rank-width | multiplication `M` |
 
-Three capabilities cut across all of these:
+Four capabilities cut across all of these:
 
 - **Composition** (`autstr.composition`) — disjoint union and direct products of
   structures, and union and finite-product closure of classes.
+- **First-order interpretations** (`autstr.interpretations`) — automatic
+  structures are closed under FO-interpretations, and `interpret` *computes* the
+  interpreted presentation: a domain formula, a formula per relation, elements as
+  k-tuples, optionally quotiented by a definable equivalence. It is how the
+  ordinals are built — three formulas over Büchi arithmetic, no automaton
+  authored.
 - **Implicit evaluation** (`autstr.implicit`) — `check_implicit` /
   `evaluate_implicit` decide formulas and compute satisfying sets *without
   building a query automaton*, reaching members whose automata are far too large

--- a/autstr/infinite_graphs.py
+++ b/autstr/infinite_graphs.py
@@ -191,3 +191,131 @@ class IntegerGrid:
 def _async_product(left, right):
     from autstr.composition import direct_product
     return direct_product(left, right, kind='async')
+
+
+# ----------------------------------------------------------------------
+# Concrete factory: the regular tree
+# ----------------------------------------------------------------------
+
+class RegularTree:
+    """The infinite k-ary tree :math:`T_k`, with its successors and the prefix
+    order.
+
+    Vertices are the words over ``{0, …, k-1}``: the root is the empty word,
+    and ``x·i`` is the i-th child of ``x``. So the tree *is* its own encoding,
+    and the relations are small automata read straight off the word operations
+    — appending one letter, and being a prefix — rather than derived from
+    another structure.
+
+    The presentation carries ``S0 … S{k-1}`` (``Si(x, y)`` iff ``y = x·i``),
+    their union ``Child``, ``Prefix`` (the reflexive prefix order, i.e.
+    ancestor-or-self), ``Eq``, and the undirected child edge ``E``, under which
+    the tree is a graph: the root has degree k and every other vertex degree
+    k+1.
+
+    :math:`T_k` is the Cayley graph of the free monoid on k generators, and the
+    2k-regular version is the Cayley graph of the free group — the same object
+    the pushdown graphs are unravelled from.
+
+    :param k: the branching degree (k ≥ 1). ``RegularTree(1)`` is a ray.
+    """
+
+    def __init__(self, k: int = 2) -> None:
+        if k < 1:
+            raise ValueError("the branching degree must be >= 1")
+        self.k = k
+        self.letters = [str(i) for i in range(k)]
+        alphabet = self.letters + [_PAD]
+
+        from autstr.presentations import AutomaticPresentation
+        automata = {'U': _words(alphabet, self.letters),
+                    'Eq': _identity(alphabet, self.letters),
+                    'Prefix': _prefix(alphabet, self.letters)}
+        automata.update({f'S{i}': _append(alphabet, self.letters, letter)
+                         for i, letter in enumerate(self.letters)})
+        self.presentation = AutomaticPresentation(automata, padding_symbol=_PAD)
+        self.presentation.update(
+            Child=' | '.join(f'S{i}(x,y)' for i in range(k)))
+        self.presentation.update(E='Child(x,y) | Child(y,x)')
+
+        self.graph = InfiniteGraph(
+            self.presentation, edge='E',
+            codec=FunctionCodec(self.encode, self.decode))
+
+    # -- element codec: a vertex as its word ---------------------------
+    def encode(self, vertex) -> list:
+        """The encoding of a vertex, written as a sequence of child indices —
+        ``(0, 1, 1)``, or the string ``'011'`` — with the empty sequence for
+        the root."""
+        word = []
+        for step in vertex:
+            index = int(step)
+            if not 0 <= index < self.k:
+                raise ValueError(
+                    f"{step!r} is not a child index of a {self.k}-ary tree")
+            word.append(self.letters[index])
+        return word
+
+    def decode(self, word) -> Tuple[int, ...]:
+        """The vertex encoded by a word, as a tuple of child indices."""
+        return tuple(int(symbol) for symbol in word if symbol != _PAD)
+
+    # -- interface -----------------------------------------------------
+    def symbolic(self, signature=None):
+        """A symbolic interface to the tree; write the child edge as
+        ``x.adj(y)`` and vertices as sequences of child indices. The
+        successors and the prefix order are reached by name, through
+        `autstr.symbolic.SymbolicContext.rel`."""
+        return self.graph.symbolic(signature)
+
+    def is_symmetric(self) -> bool:
+        return self.graph.is_symmetric()
+
+    def check(self, phi) -> bool:
+        return self.graph.check(phi)
+
+    def evaluate(self, phi):
+        return self.graph.evaluate(phi)
+
+    def get_relation_symbols(self):
+        return self.presentation.get_relation_symbols()
+
+    def __repr__(self):
+        return f"<RegularTree branching={self.k}>"
+
+
+def _dfa(alphabet, arity: int, transitions, initial: str, final):
+    from autstr.utils.automata_tools import partial_dfa
+    return partial_dfa(set(alphabet), arity, transitions, initial, set(final))
+
+
+def _words(alphabet, letters):
+    """The universe: every word over the child letters, the root included."""
+    return _dfa(alphabet, 1,
+                {'w': {(letter,): 'w' for letter in letters}},
+                initial='w', final={'w'})
+
+
+def _identity(alphabet, letters):
+    """``x = y``, on the convolution of two words."""
+    return _dfa(alphabet, 2,
+                {'s': {(letter, letter): 's' for letter in letters}},
+                initial='s', final={'s'})
+
+
+def _append(alphabet, letters, letter):
+    """``y = x·letter``: the tapes agree while x runs, then x pads out and y
+    carries the one extra letter."""
+    table = {'s': {(a, a): 's' for a in letters}}
+    table['s'][(_PAD, letter)] = 'done'
+    table['done'] = {}
+    return _dfa(alphabet, 2, table, initial='s', final={'done'})
+
+
+def _prefix(alphabet, letters):
+    """``x`` is a prefix of ``y``, reflexively: the tapes agree while x runs,
+    and whatever y has left is the descent below it."""
+    table = {'s': {(a, a): 's' for a in letters},
+             'below': {(_PAD, a): 'below' for a in letters}}
+    table['s'].update({(_PAD, a): 'below' for a in letters})
+    return _dfa(alphabet, 2, table, initial='s', final={'s', 'below'})

--- a/autstr/infinite_graphs.py
+++ b/autstr/infinite_graphs.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Optional, Sequence, Tuple
 
 from autstr.symbolic import FunctionCodec, graph_signature
+from autstr.utils.automata_tools import partial_dfa
 
 
 class InfiniteGraph:
@@ -225,7 +226,7 @@ class RegularTree:
             raise ValueError("the branching degree must be >= 1")
         self.k = k
         self.letters = [str(i) for i in range(k)]
-        alphabet = self.letters + [_PAD]
+        alphabet = set(self.letters) | {_PAD}
 
         from autstr.presentations import AutomaticPresentation
         automata = {'U': _words(alphabet, self.letters),
@@ -284,23 +285,18 @@ class RegularTree:
         return f"<RegularTree branching={self.k}>"
 
 
-def _dfa(alphabet, arity: int, transitions, initial: str, final):
-    from autstr.utils.automata_tools import partial_dfa
-    return partial_dfa(set(alphabet), arity, transitions, initial, set(final))
-
-
 def _words(alphabet, letters):
     """The universe: every word over the child letters, the root included."""
-    return _dfa(alphabet, 1,
-                {'w': {(letter,): 'w' for letter in letters}},
-                initial='w', final={'w'})
+    return partial_dfa(alphabet, 1,
+                       {'w': {(letter,): 'w' for letter in letters}},
+                       initial='w', final={'w'})
 
 
 def _identity(alphabet, letters):
     """``x = y``, on the convolution of two words."""
-    return _dfa(alphabet, 2,
-                {'s': {(letter, letter): 's' for letter in letters}},
-                initial='s', final={'s'})
+    return partial_dfa(alphabet, 2,
+                       {'s': {(letter, letter): 's' for letter in letters}},
+                       initial='s', final={'s'})
 
 
 def _append(alphabet, letters, letter):
@@ -309,7 +305,7 @@ def _append(alphabet, letters, letter):
     table = {'s': {(a, a): 's' for a in letters}}
     table['s'][(_PAD, letter)] = 'done'
     table['done'] = {}
-    return _dfa(alphabet, 2, table, initial='s', final={'done'})
+    return partial_dfa(alphabet, 2, table, initial='s', final={'done'})
 
 
 def _prefix(alphabet, letters):
@@ -318,4 +314,5 @@ def _prefix(alphabet, letters):
     table = {'s': {(a, a): 's' for a in letters},
              'below': {(_PAD, a): 'below' for a in letters}}
     table['s'].update({(_PAD, a): 'below' for a in letters})
-    return _dfa(alphabet, 2, table, initial='s', final={'s', 'below'})
+    return partial_dfa(alphabet, 2, table, initial='s',
+                       final={'s', 'below'})

--- a/autstr/ordinals.py
+++ b/autstr/ordinals.py
@@ -1,0 +1,183 @@
+"""Ordinals below :math:`\\omega^\\omega`, as automatic structures.
+
+Delhommé's theorem draws the line exactly here: the word-automatic ordinals are
+precisely those below :math:`\\omega^\\omega`. Every one of them lives in some
+:math:`\\omega^n`, so a factory for :math:`(\\omega^n, <)` covers all of them —
+and past that boundary the string engine cannot go. (:math:`\\omega^{\\omega}`
+itself and everything up to :math:`\\omega^{\\omega^\\omega}` needs the tree
+engine.)
+
+The structure is *derived, not authored*. By Cantor normal form an ordinal
+:math:`\\alpha < \\omega^n` is uniquely :math:`\\sum_{i<n} \\omega^i c_i` with
+natural coefficients, so :math:`\\omega^n` is the set of n-tuples of naturals
+under reverse-lexicographic order — an n-dimensional first-order interpretation
+of Büchi arithmetic::
+
+    >>> W2 = Ordinal(2)                       # the ordinals below ω²
+    >>> S = W2.symbolic()
+    >>> a, b = S.vars("a b")
+    >>> a.lt(b).evaluate().contains(a=(0, 7), b=(1, 0))   # 7 < ω
+    True
+
+Ordinals are written as Python tuples of Cantor coefficients in *descending*
+exponent order, so ``(3, 2, 5)`` in ``Ordinal(3)`` is
+:math:`\\omega^2 \\cdot 3 + \\omega \\cdot 2 + 5` and tuples compare
+lexicographically exactly as the ordinals do. A plain integer is the finite
+ordinal of that value.
+
+The signature carries the strict order ``.lt``, equality ``.eq`` and the
+successor ``.succ``. Everything else is first-order over those and can be
+defined on the spot: a limit ordinal is one that is neither zero nor a
+successor, and ``Ordinal(n)`` has a definable least element but no greatest.
+"""
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple, Union
+
+from autstr.buildin.presentations import BuechiArithmetic
+from autstr.interpretations import interpret
+from autstr.symbolic import FunctionCodec, order_signature
+
+#: base-2 encoding of a natural, least significant bit first — the convention
+#: of the Büchi arithmetic presentation over ℕ
+_PAD = '*'
+
+#: the constant 1 of Büchi arithmetic: the least power of two
+_ONE = 'Pt(o) & (all p.(Pt(p) -> (not Lt(p,o))))'
+
+#: a Python ordinal: coefficients in descending exponent order, or an integer
+OrdinalValue = Union[int, Sequence[int]]
+
+
+def _encode_nat(value: int) -> List[str]:
+    """The word encoding a natural number: binary, least significant bit
+    first."""
+    if value < 0:
+        raise ValueError(f"a Cantor coefficient must be a natural, got {value}")
+    return list(format(value, 'b')[::-1])
+
+
+def _decode_nat(word) -> int:
+    """The natural number encoded by a word, ignoring padding."""
+    bits = ''.join(symbol for symbol in word if symbol != _PAD)
+    if not bits:
+        raise ValueError("empty encoding")
+    return int(bits[::-1], base=2)
+
+
+class Ordinal:
+    """The ordinals below :math:`\\omega^n`, under their natural order.
+
+    :param n: the exponent (n ≥ 1). ``Ordinal(1)`` is :math:`(\\omega, <)`,
+        i.e. the naturals; ``Ordinal(2)`` is :math:`(\\omega^2, <)`.
+
+    The presentation carries ``Lt`` (the strict order), ``Eq`` and ``Succ``
+    (the graph of the successor function, ``Succ(x, y)`` iff ``y = x + 1``).
+    """
+
+    def __init__(self, n: int = 1) -> None:
+        if n < 1:
+            raise ValueError("the exponent must be >= 1")
+        self.n = n
+        coefficients = [f'x{i}' for i in range(n)]      # x_i: coefficient of ω^i
+        others = [f'y{i}' for i in range(n)]
+        pair = coefficients + others
+
+        self.presentation = interpret(
+            BuechiArithmetic(),
+            domain=(' & '.join(f'Eq({c},{c})' for c in coefficients),
+                    coefficients),
+            relations={
+                'Lt': (self._less(n), pair),
+                'Eq': (' & '.join(f'Eq(x{i},y{i})' for i in range(n)), pair),
+                'Succ': (self._successor(n), pair),
+            },
+            dimension=n)
+
+    @staticmethod
+    def _less(n: int) -> str:
+        """Reverse-lexicographic order on the coefficients: compare the most
+        significant one first. First-order for each fixed n — a disjunction
+        over which exponent the two ordinals first differ at."""
+        terms = []
+        for i in reversed(range(n)):
+            agree = [f'Eq(x{j},y{j})' for j in range(i + 1, n)]
+            terms.append(' & '.join([f'Lt(x{i},y{i})'] + agree))
+        return ' | '.join(f'({term})' for term in terms)
+
+    @staticmethod
+    def _successor(n: int) -> str:
+        """``y = x + 1``: add one to the constant coefficient and hold the
+        rest. Every ordinal has a successor, so this is a total function."""
+        held = [f'Eq(x{j},y{j})' for j in range(1, n)]
+        add_one = f'exists o.(({_ONE}) & A(x0,o,y0))'
+        return ' & '.join([f'({add_one})'] + held)
+
+    # -- element codec: a Cantor normal form <-> its folded encoding ----
+    def encode(self, value: OrdinalValue) -> list:
+        """The encoding of an ordinal written as its Cantor coefficients in
+        descending exponent order (or as a plain integer, for a finite
+        ordinal)."""
+        coefficients = self._coefficients(value)
+        words = [_encode_nat(c) for c in reversed(coefficients)]  # x0 first
+        if self.n == 1:
+            return words[0]
+        length = max(len(word) for word in words)
+        return [tuple(word[k] if k < len(word) else _PAD for word in words)
+                for k in range(length)]
+
+    def decode(self, word) -> Tuple[int, ...]:
+        """The ordinal encoded by a word, as a tuple of Cantor coefficients in
+        descending exponent order."""
+        if self.n == 1:
+            return (_decode_nat(word),)
+        return tuple(reversed([_decode_nat([letter[i] for letter in word])
+                               for i in range(self.n)]))
+
+    def _coefficients(self, value: OrdinalValue) -> Tuple[int, ...]:
+        """`value` as a full n-tuple of coefficients, descending exponent."""
+        if isinstance(value, int):
+            value = (value,)
+        coefficients = tuple(value)
+        if len(coefficients) > self.n:
+            raise ValueError(
+                f"{value!r} has {len(coefficients)} coefficients, more than "
+                f"the {self.n} of an ordinal below omega^{self.n}")
+        return (0,) * (self.n - len(coefficients)) + coefficients
+
+    # -- interface -----------------------------------------------------
+    def default_signature(self):
+        """The signature `symbolic()` uses when none is given: ``.lt``,
+        ``.eq`` and ``.succ``, with ordinals written as coefficient tuples."""
+        return order_signature(self.presentation.get_relation_symbols(),
+                               less='Lt', methods={'succ': 'Succ'},
+                               codec=FunctionCodec(self.encode, self.decode))
+
+    def symbolic(self, signature=None):
+        """A symbolic interface to the order; write ``a.lt(b)`` and ordinals as
+        Python coefficient tuples."""
+        return self.presentation.symbolic(signature or self.default_signature())
+
+    def check(self, phi) -> bool:
+        """Truth of a formula over the ordinals (free variables existential)."""
+        return self.presentation.check(phi)
+
+    def evaluate(self, phi):
+        """The relation of satisfying assignments of a formula."""
+        return self.presentation.evaluate(phi)
+
+    def get_relation_symbols(self):
+        """All relation symbols of the structure ('U' is the domain)."""
+        return self.presentation.get_relation_symbols()
+
+    def is_total_order(self) -> bool:
+        """Whether ``Lt`` is a strict total order — decidable, being a
+        first-order question. Well-foundedness is *not* first-order, so it is
+        not checkable here; it holds by construction."""
+        return self.presentation.check(
+            'all x.(not Lt(x,x)) & '
+            'all x.(all y.(all z.((Lt(x,y) & Lt(y,z)) -> Lt(x,z)))) & '
+            'all x.(all y.(Lt(x,y) | Lt(y,x) | Eq(x,y)))')
+
+    def __repr__(self):
+        return f"<Ordinal omega^{self.n}>"

--- a/autstr/presentations.py
+++ b/autstr/presentations.py
@@ -271,6 +271,30 @@ class AutomaticPresentation(DeferredRelations):
             ).minimize()
         return domain
 
+    def _operand_automaton(self, psi, free_operand: List[str],
+                           free_vars: List[str], verbose=False) -> SparseDFA:
+        """A connective's operand, placed into the enclosing formula's tape
+        order.
+
+        A sentence has no tapes to place: it collapses to the all/none marker,
+        whose single tape is a placeholder rather than a variable, so renaming
+        it into the enclosing arity is meaningless (and, when the enclosing
+        formula is itself a sentence, impossible — there is no tape to rename
+        to). It is remade at the enclosing arity instead: false becomes the
+        empty relation, true the full one, which over a structure is the
+        product of universes rather than every word.
+        """
+        dfa = self._build_automaton(psi, verbose=verbose, init=False)
+        arity = max(len(free_vars), 1)
+        if free_operand:
+            return expand(dfa, arity, [free_vars.index(v) for v in free_operand])
+        if dfa.is_empty():
+            return zero(symbol_arity=arity, base_alphabet=self.sigma)
+        # a true sentence: the marker convention at arity 1, so that an
+        # enclosing sentence stays a marker; the domain otherwise
+        return one(base_alphabet=self.sigma) if not free_vars \
+            else self._domain_product(arity)
+
     def check(self, phi: logic.Expression | str) -> bool:
         """Checks if a given first-order formula holds on the presented structure. Free variables are assumed be
         implicitly existentially quantified.
@@ -424,8 +448,8 @@ class AutomaticPresentation(DeferredRelations):
             free_l = get_free_elementary_vars(left)
             free_r = get_free_elementary_vars(right)
 
-            dfa_l = expand(self._build_automaton(left, verbose=verbose, init=False), len(free_vars), pos=[free_vars.index(v) for v in free_l])
-            dfa_r = expand(self._build_automaton(right, verbose=verbose, init=False), len(free_vars), pos=[free_vars.index(v) for v in free_r])
+            dfa_l = self._operand_automaton(left, free_l, free_vars, verbose)
+            dfa_r = self._operand_automaton(right, free_r, free_vars, verbose)
 
             result = dfa_l.intersection(dfa_r).minimize()
             if verbose:
@@ -440,8 +464,8 @@ class AutomaticPresentation(DeferredRelations):
             free_l = get_free_elementary_vars(left)
             free_r = get_free_elementary_vars(right)
 
-            dfa_l = expand(self._build_automaton(left, verbose=verbose, init=False), len(free_vars), pos=[free_vars.index(v) for v in free_l])
-            dfa_r = expand(self._build_automaton(right, verbose=verbose, init=False), len(free_vars), pos=[free_vars.index(v) for v in free_r])
+            dfa_l = self._operand_automaton(left, free_l, free_vars, verbose)
+            dfa_r = self._operand_automaton(right, free_r, free_vars, verbose)
 
             result = dfa_l.union(dfa_r).minimize()
             if verbose:

--- a/autstr/symbolic/__init__.py
+++ b/autstr/symbolic/__init__.py
@@ -29,7 +29,8 @@ from autstr.symbolic.compiler import CompileError
 from autstr.symbolic.expr import Formula, Term, Var
 from autstr.symbolic.signature import (
     ElementCodec, EQUALITY_SYMBOL, Function, FunctionCodec, Signature,
-    graph_signature, operation_signature,
+    graph_signature, operation_signature, order_signature,
+    relational_signature,
 )
 
 # `Function` is importable from here but deliberately absent from __all__:
@@ -42,5 +43,5 @@ __all__ = [
     'FunctionCodec', 'FunctionSymbol', 'Relation',
     'RelationSymbol', 'Signature', 'StructureBackend', 'SymbolicContext',
     'SymbolicSymbolError', 'Term', 'Var', 'graph_signature',
-    'operation_signature',
+    'operation_signature', 'order_signature', 'relational_signature',
 ]

--- a/autstr/symbolic/signature.py
+++ b/autstr/symbolic/signature.py
@@ -75,6 +75,33 @@ def operation_signature(relations, graph: str, operator: str,
     return signature
 
 
+def relational_signature(relations, methods: Dict[str, str],
+                         equality: str = EQUALITY_SYMBOL,
+                         codec=None) -> 'Signature':
+    """The signature of a purely relational structure: each method name in
+    `methods` bound to the relation symbol it names, plus equality when the
+    structure declares it.
+
+    Nothing binds to ``+`` or ``*`` — a relational structure carries no
+    operation, so every symbol is reached as a method, exactly like ``.lt`` in
+    the arithmetic signature. The requested methods are bound whether or not
+    the structure declares them, so a symbol that is missing fails loudly when
+    a formula uses it rather than silently going unbound; only equality, which
+    a caller asks for generically, is conditional.
+
+    :param relations: the structure's relation symbols.
+    :param methods: ``{method name: relation symbol}``.
+    :param equality: the equality symbol, bound to ``.eq`` when present.
+    :param codec: optional element codec for writing elements as constants.
+    """
+    signature = Signature(codec=codec)
+    for method, symbol in methods.items():
+        signature.operator(method, symbol)
+    if equality in relations:
+        signature.operator('eq', equality)
+    return signature
+
+
 def graph_signature(relations, edge: str = 'E', adjacency: str = 'adj',
                     equality: str = EQUALITY_SYMBOL, codec=None) -> 'Signature':
     """The signature of a graph: the binary edge relation `edge` bound to the
@@ -91,11 +118,29 @@ def graph_signature(relations, edge: str = 'E', adjacency: str = 'adj',
     :param adjacency: the method name it binds to.
     :param codec: optional element codec for writing vertices as constants.
     """
-    signature = Signature(codec=codec)
-    signature.operator(adjacency, edge)
-    if equality in relations:
-        signature.operator('eq', equality)
-    return signature
+    return relational_signature(relations, {adjacency: edge},
+                                equality=equality, codec=codec)
+
+
+def order_signature(relations, less: str = 'Lt', order: str = 'lt',
+                    equality: str = EQUALITY_SYMBOL, codec=None,
+                    methods: Optional[Dict[str, str]] = None) -> 'Signature':
+    """The signature of an ordered structure: the binary relation `less` bound
+    to ``.{order}(y)`` (default ``.lt``), plus equality when declared.
+
+    An order is not a graph — ``x.lt(y)`` and ``x.adj(y)`` read differently
+    even where both are binary — so orders get their own vocabulary rather than
+    being wrapped as graphs. Further relations of the same structure (a
+    successor, a limit predicate) go in `methods`.
+
+    :param relations: the structure's relation symbols.
+    :param less: the binary relation read as the strict order.
+    :param order: the method name it binds to.
+    :param codec: optional element codec for writing elements as constants.
+    :param methods: further ``{method name: relation symbol}`` bindings.
+    """
+    return relational_signature(relations, {order: less, **(methods or {})},
+                                equality=equality, codec=codec)
 
 
 class ElementCodec:

--- a/autstr/turing.py
+++ b/autstr/turing.py
@@ -1,0 +1,329 @@
+"""Turing machines and their configuration graphs.
+
+The configuration graph of a Turing machine is the standard example of an
+automatic structure that is genuinely *about* computation: a configuration is a
+word, and one step of the machine rewrites that word locally, at the head, so
+the step relation is recognized by a small synchronous automaton — one whose
+size depends only on the transition table, not on the tape.
+
+That makes the first-order theory of the graph decidable, and this module lets
+you ask it::
+
+    >>> machine = TuringMachine(
+    ...     transitions={('q', '1'): ('q', '1', 'R'),
+    ...                  ('q', '_'): ('halt', '1', 'S')},
+    ...     blank='_')
+    >>> graph = machine.configuration_graph()
+    >>> graph.check('all x.(all y.(all z.((E(x,y) & E(x,z)) -> Eq(y,z))))')
+    True
+
+**The boundary lesson.** Reachability — "does some sequence of steps lead from
+this configuration to a halting one?" — is exactly the halting problem, so it
+is undecidable, and therefore *not first-order definable* over this graph.
+Nothing here provides it, and nothing can: the transitive closure of ``E`` is
+outside FO. A decidable first-order theory is not a decidable graph. It is the
+same lesson as the random graph in reverse — there, a decidable theory without
+an automatic presentation; here, an automatic presentation whose decidable
+theory still cannot express the one question you would most like to ask.
+
+**Encoding.** The tape is one-way infinite, to the right. A configuration is
+the word ``left · (state, symbol) · right``: the tape contents, with the cell
+under the head replaced by a symbol naming both the state and what is written
+there. Trailing blanks are dropped, so each configuration has exactly one word.
+A step changes the word only at the head and, at most, by one cell at the right
+end, which is why a synchronous automaton can read it. A left move off cell 0
+has no successor, as does a configuration whose ``(state, symbol)`` pair the
+transition table does not list — those are the halting configurations, and
+``Halt`` is defined from ``E`` rather than authored.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence, Tuple
+
+from autstr.infinite_graphs import InfiniteGraph
+from autstr.symbolic import FunctionCodec
+from autstr.utils.automata_tools import partial_dfa
+
+#: the padding symbol of the configuration encoding
+_PAD = '*'
+
+#: how a transition may move the head
+DIRECTIONS = ('L', 'R', 'S')
+
+
+@dataclass(frozen=True)
+class Configuration:
+    """A machine configuration: the control state, the tape, and where the
+    head is.
+
+    :param state: the control state.
+    :param tape: the tape contents from cell 0, as a tuple of tape symbols.
+    :param head: the index of the cell under the head.
+    """
+    state: str
+    tape: Tuple[str, ...]
+    head: int = 0
+
+    def __post_init__(self):
+        if not 0 <= self.head < max(len(self.tape), 1):
+            raise ValueError(
+                f"the head is at cell {self.head}, off a tape of "
+                f"{len(self.tape)} cell(s)")
+
+
+class TuringMachine:
+    """A deterministic single-tape Turing machine with a one-way infinite
+    tape.
+
+    :param transitions: ``{(state, read): (state, write, direction)}``, with
+        direction one of ``'L'``, ``'R'``, ``'S'``. A pair the table omits is
+        halting.
+    :param blank: the blank symbol, which fills the tape beyond what has been
+        written.
+    :param states: the control states. Read off the table when omitted.
+    :param tape_alphabet: the tape symbols. Read off the table when omitted;
+        the blank always belongs.
+    """
+
+    def __init__(self, transitions: Dict[Tuple[str, str], Tuple[str, str, str]],
+                 blank: str = '_', states: Optional[Sequence[str]] = None,
+                 tape_alphabet: Optional[Sequence[str]] = None) -> None:
+        self.blank = blank
+        self.transitions = dict(transitions)
+
+        mentioned_states, mentioned_symbols = set(), {blank}
+        for (state, read), (target, write, direction) in self.transitions.items():
+            if direction not in DIRECTIONS:
+                raise ValueError(
+                    f"{direction!r} is not a direction; use one of "
+                    f"{', '.join(DIRECTIONS)}")
+            mentioned_states |= {state, target}
+            mentioned_symbols |= {read, write}
+
+        self.states = sorted(mentioned_states | set(states or ()))
+        self.tape_alphabet = sorted(mentioned_symbols | set(tape_alphabet or ()))
+        if blank not in self.tape_alphabet:
+            raise ValueError(f"the blank {blank!r} is not a tape symbol")
+        for symbol in self.tape_alphabet + self.states:
+            if symbol == _PAD:
+                raise ValueError(f"{_PAD!r} is reserved as the padding symbol")
+
+        #: the head letters: one per (state, symbol) pair
+        self._head_letters = {(q, a): f'{q}|{a}'
+                              for q in self.states for a in self.tape_alphabet}
+        self.alphabet = (list(self.tape_alphabet)
+                         + sorted(self._head_letters.values()) + [_PAD])
+
+    # -- the machine itself --------------------------------------------
+    def canonical(self, configuration: Configuration) -> Configuration:
+        """The configuration with trailing blanks past the head dropped — the
+        one word that stands for it."""
+        tape = list(configuration.tape) or [self.blank]
+        while len(tape) - 1 > configuration.head and tape[-1] == self.blank:
+            tape.pop()
+        return Configuration(configuration.state, tuple(tape),
+                             configuration.head)
+
+    def step(self, configuration: Configuration) -> Optional[Configuration]:
+        """The successor configuration, or None if there is none — the
+        transition table does not cover this ``(state, symbol)`` pair, or the
+        head would move off the left end of the tape.
+
+        This is the Python oracle the automaton is checked against, and the
+        obvious way to run the machine.
+        """
+        configuration = self.canonical(configuration)
+        tape = list(configuration.tape)
+        key = (configuration.state, tape[configuration.head])
+        if key not in self.transitions:
+            return None
+        state, write, direction = self.transitions[key]
+
+        tape[configuration.head] = write
+        head = configuration.head + {'L': -1, 'R': 1, 'S': 0}[direction]
+        if head < 0:
+            return None
+        if head == len(tape):
+            tape.append(self.blank)
+        return self.canonical(Configuration(state, tuple(tape), head))
+
+    def run(self, configuration: Configuration, limit: int = 1000):
+        """The run from a configuration: it, then its successors, stopping when
+        the machine halts or after `limit` steps."""
+        current = self.canonical(configuration)
+        yield current
+        for _ in range(limit):
+            current = self.step(current)
+            if current is None:
+                return
+            yield current
+
+    # -- the configuration graph ---------------------------------------
+    def configuration_graph(self) -> 'ConfigurationGraph':
+        """The graph of configurations under one step of the machine."""
+        return ConfigurationGraph(self)
+
+    # -- element codec: a configuration <-> its word --------------------
+    def encode(self, configuration: Configuration) -> list:
+        """The word encoding a configuration."""
+        configuration = self.canonical(configuration)
+        word = list(configuration.tape)
+        head = configuration.head
+        word[head] = self._head_letters[(configuration.state, word[head])]
+        return word
+
+    def decode(self, word) -> Configuration:
+        """The configuration a word encodes."""
+        tape, state, head = [], None, None
+        for position, symbol in enumerate(word):
+            if symbol == _PAD:
+                break
+            if '|' in symbol:
+                state, _, cell = symbol.partition('|')
+                head = position
+                tape.append(cell)
+            else:
+                tape.append(symbol)
+        if head is None:
+            raise ValueError(f"{word!r} carries no head, so it is no "
+                             f"configuration")
+        return Configuration(state, tuple(tape), head)
+
+
+class ConfigurationGraph:
+    """The configuration graph of a `TuringMachine`: configurations as
+    vertices, one machine step as a directed edge.
+
+    The presentation carries ``E`` (one step), ``Eq``, and ``Halt`` — the
+    configurations with no successor, *defined* as ``not exists y. E(x,y)``
+    rather than authored, since the engine can compute it.
+
+    Reachability is deliberately absent; see the module docstring.
+    """
+
+    def __init__(self, machine: TuringMachine) -> None:
+        from autstr.presentations import AutomaticPresentation
+        self.machine = machine
+
+        presentation = AutomaticPresentation(
+            {'U': _configurations(machine),
+             'Eq': _identity(machine),
+             'E': _step(machine)},
+            padding_symbol=_PAD)
+        presentation.update(Halt='not exists y.(E(x,y))')
+        self.presentation = presentation
+        self.graph = InfiniteGraph(
+            presentation, edge='E', directed=True,
+            codec=FunctionCodec(machine.encode, machine.decode))
+
+    def symbolic(self, signature=None):
+        """A symbolic interface to the graph; write one step as ``x.adj(y)``
+        and configurations as `Configuration` values."""
+        return self.graph.symbolic(signature)
+
+    def check(self, phi) -> bool:
+        return self.graph.check(phi)
+
+    def evaluate(self, phi):
+        return self.graph.evaluate(phi)
+
+    def get_relation_symbols(self):
+        return self.presentation.get_relation_symbols()
+
+    def is_deterministic(self) -> bool:
+        """Whether every configuration has at most one successor — a
+        first-order question, and so decidable here, unlike reachability."""
+        return self.presentation.check(
+            'all x.(all y.(all z.((E(x,y) & E(x,z)) -> Eq(y,z))))')
+
+    def __repr__(self):
+        return (f"<ConfigurationGraph states={len(self.machine.states)} "
+                f"alphabet={len(self.machine.tape_alphabet)}>")
+
+
+# ----------------------------------------------------------------------
+# the automata
+# ----------------------------------------------------------------------
+
+def _configurations(machine: TuringMachine):
+    """The universe: words with exactly one head letter, not ending in a
+    blank — so each configuration has exactly one encoding."""
+    blank, heads = machine.blank, machine._head_letters.values()
+    plain = [a for a in machine.tape_alphabet if a != blank]
+
+    table = {
+        # before the head, a blank is an ordinary cell: what follows keeps it
+        # from being trailing
+        'before': {(blank,): 'before', **{(a,): 'before' for a in plain},
+                   **{(h,): 'after' for h in heads}},
+        # after the head, a word may not stop on a blank — that encoding is
+        # the same configuration as the word without it
+        'after': {(blank,): 'trailing', **{(a,): 'after' for a in plain}},
+        'trailing': {(blank,): 'trailing', **{(a,): 'after' for a in plain}},
+    }
+    return partial_dfa(set(machine.alphabet), 1, table, 'before', {'after'})
+
+
+def _identity(machine: TuringMachine):
+    """``x = y`` on configuration words."""
+    letters = [a for a in machine.alphabet if a != _PAD]
+    return partial_dfa(set(machine.alphabet), 2,
+                       {'s': {(a, a): 's' for a in letters}}, 's', {'s'})
+
+
+def _step(machine: TuringMachine):
+    """One machine step, as a synchronous two-tape automaton.
+
+    Reading the two words in lockstep, the automaton walks the agreeing prefix,
+    applies the local rewrite where the head is, and walks the agreeing suffix.
+    A left move is the one case needing lookahead — the head lands on the cell
+    *before* the one being read — and is handled by remembering, for one
+    symbol, which control state the target word's head announced.
+    """
+    blank, pad = machine.blank, _PAD
+    head_letter = machine._head_letters
+    cells = machine.tape_alphabet
+
+    # the agreeing prefix, and the two ways a rewrite can start
+    prefix = {(a, a): 'prefix' for a in cells}
+    for (state, read), (target, write, direction) in machine.transitions.items():
+        source = head_letter[(state, read)]
+        if direction == 'R':
+            # the head letter becomes what was written; the head reappears on
+            # the next cell, which the target word announces
+            prefix[(source, write)] = f'right:{target}'
+        elif direction == 'S':
+            prefix[(source, head_letter[(target, write)])] = 'suffix'
+        else:                                   # 'L': the head moves back one
+            for cell in cells:
+                # the target word already carries its head on the cell just
+                # read — unchanged, which this pair checks — so remember the
+                # state it announced and check the rewrite on the next symbol
+                prefix[(cell, head_letter[(target, cell)])] = f'left:{target}'
+
+    table = {'prefix': prefix,
+             'suffix': {(a, a): 'suffix' for a in cells},
+             'end': {}}
+
+    for state in machine.states:
+        # a right move: the target's head sits on the next cell, which holds
+        # whatever the source had there — or a blank, when the tape grows
+        table[f'right:{state}'] = {
+            **{(a, head_letter[(state, a)]): 'suffix' for a in cells},
+            (pad, head_letter[(state, blank)]): 'end',
+        }
+
+    for (state, read), (target, write, direction) in machine.transitions.items():
+        if direction != 'L':
+            continue
+        source = head_letter[(state, read)]
+        row = table.setdefault(f'left:{target}', {})
+        row[(source, write)] = 'suffix'
+        if write == blank:
+            # the written blank would now be the last cell: it is dropped, and
+            # the target word is one shorter
+            row[(source, pad)] = 'end'
+
+    return partial_dfa(set(machine.alphabet), 2, table, 'prefix',
+                       {'suffix', 'end'})

--- a/autstr/utils/automata_tools.py
+++ b/autstr/utils/automata_tools.py
@@ -754,8 +754,8 @@ def partial_dfa(base_alphabet: Set, arity: int,
     Every symbol tuple a state does not list goes to a rejecting sink, which is
     what an automaton authored by hand almost always wants: the interesting
     transitions are few and the alphabet — a product of k copies of the base —
-    is large, so spelling the table out in full costs |Σ|^k entries per state
-    to say "reject" over and over.
+    is large, so spelling the table out in full costs ``|Σ|^k`` entries per
+    state to say "reject" over and over.
 
     :param base_alphabet: the base alphabet, padding symbol included.
     :param arity: number of tapes; the automaton reads `arity`-tuples.

--- a/autstr/utils/automata_tools.py
+++ b/autstr/utils/automata_tools.py
@@ -745,3 +745,59 @@ def lsbf_Z_automaton(z: int) -> SparseDFA:
         symbol_arity=1,
         base_alphabet={"*", "0", "1"}  # "*"=0, "0"=1, "1"=2
     )
+
+def partial_dfa(base_alphabet: Set, arity: int,
+                transitions: Dict[str, Dict[tuple, str]],
+                initial: str, final: Set[str]) -> SparseDFA:
+    """A DFA over `arity` tapes from a *partial* transition table.
+
+    Every symbol tuple a state does not list goes to a rejecting sink, which is
+    what an automaton authored by hand almost always wants: the interesting
+    transitions are few and the alphabet — a product of k copies of the base —
+    is large, so spelling the table out in full costs |Σ|^k entries per state
+    to say "reject" over and over.
+
+    :param base_alphabet: the base alphabet, padding symbol included.
+    :param arity: number of tapes; the automaton reads `arity`-tuples.
+    :param transitions: ``{state: {symbol tuple: target state}}``. Its keys are
+        the states, in the order they are numbered.
+    :param initial: the start state.
+    :param final: the accepting states.
+    :return: a minimized `SparseDFA`.
+    """
+    states = list(transitions)
+    if initial not in states:
+        raise ValueError(f"the start state {initial!r} has no row in the table")
+    unknown = {target for row in transitions.values() for target in row.values()}
+    unknown |= set(final)
+    unknown -= set(states)
+    if unknown:
+        raise ValueError(f"states without a row in the table: {sorted(unknown)}")
+
+    sink = len(states)                       # the implicit rejecting state
+    index = {state: i for i, state in enumerate(states)}
+    rows = [sorted((encode_symbol(symbol, base_alphabet), index[target])
+                   for symbol, target in transitions[state].items())
+            for state in states]
+    width = max([len(row) for row in rows], default=0)
+
+    exception_symbols = np.full((sink + 1, width), -1, dtype=np.int32)
+    exception_states = np.full((sink + 1, width), -1, dtype=np.int32)
+    for i, row in enumerate(rows):
+        exception_symbols[i, :len(row)] = [symbol for symbol, _ in row]
+        exception_states[i, :len(row)] = [target for _, target in row]
+
+    is_accepting = np.zeros(sink + 1, dtype=bool)
+    for state in final:
+        is_accepting[index[state]] = True
+
+    return SparseDFA(
+        num_states=sink + 1,
+        default_states=np.full(sink + 1, sink, dtype=np.int32),
+        exception_symbols=exception_symbols,
+        exception_states=exception_states,
+        is_accepting=is_accepting,
+        start_state=index[initial],
+        symbol_arity=arity,
+        base_alphabet=set(base_alphabet),
+    ).minimize()

--- a/tests/test_automata_tools.py
+++ b/tests/test_automata_tools.py
@@ -12,7 +12,8 @@ import pytest
 
 from autstr.sparse_automata import SparseDFA
 from autstr.utils.automata_tools import (
-    expand, fold_tapes, pad, permute_tapes, projection, shortlex_order, unpad,
+    expand, fold_tapes, pad, partial_dfa, permute_tapes, projection,
+    shortlex_order, unpad,
 )
 
 
@@ -232,3 +233,36 @@ class TestShortlexOrder:
         order = shortlex_order({0, 1, 2}, 0)          # 0 pad, letters 1, 2
         assert order.accepts([(2, 1), (0, 1)])        # [2] < [1,1]  (shorter)
         assert not order.accepts([(1, 1), (1, 0)])    # [1,1] not <= [1]
+
+
+class TestPartialDFA:
+    """A transition table with the rejecting majority left out."""
+
+    def test_unlisted_symbols_reject(self):
+        # accepts exactly the word 'ab' over {a, b}
+        dfa = partial_dfa({'a', 'b'}, 1,
+                          {'0': {('a',): '1'}, '1': {('b',): '2'}, '2': {}},
+                          initial='0', final={'2'})
+        assert dfa.accepts([('a',), ('b',)])
+        for word in [[], [('a',)], [('b',), ('a',)], [('a',), ('b',), ('a',)]]:
+            assert not dfa.accepts(word), word
+
+    def test_a_product_alphabet_needs_only_the_listed_pairs(self):
+        # the diagonal over a 3-letter alphabet: 3 entries, not 9
+        letters = {'a', 'b', 'c'}
+        table = {'s': {(letter, letter): 's' for letter in letters}}
+        diagonal = partial_dfa(letters, 2, table, 's', {'s'})
+        assert diagonal.accepts([('a', 'a'), ('c', 'c')])
+        assert not diagonal.accepts([('a', 'a'), ('c', 'b')])
+
+    def test_an_unreachable_start_state_is_rejected(self):
+        with pytest.raises(ValueError, match="start state"):
+            partial_dfa({'a'}, 1, {'s': {}}, initial='t', final={'s'})
+
+    def test_a_target_without_a_row_is_rejected(self):
+        with pytest.raises(ValueError, match="without a row"):
+            partial_dfa({'a'}, 1, {'s': {('a',): 'gone'}}, 's', {'s'})
+
+    def test_an_accepting_state_without_a_row_is_rejected(self):
+        with pytest.raises(ValueError, match="without a row"):
+            partial_dfa({'a'}, 1, {'s': {}}, 's', {'other'})

--- a/tests/test_ordinals.py
+++ b/tests/test_ordinals.py
@@ -1,0 +1,137 @@
+"""The ordinals below ω^ω, as n-dimensional interpretations of ℕ.
+
+The oracle is Python itself: an ordinal below ω^n is its tuple of Cantor
+coefficients in descending exponent order, and ordinal comparison is that
+tuple's lexicographic order. So every order fact checked here has an
+independent ground truth that needs no automaton.
+
+ω³ is exercised sparingly — the interpretation is three-dimensional and its
+sentences are correspondingly expensive.
+"""
+import itertools
+
+import pytest
+
+from autstr.ordinals import Ordinal
+
+
+@pytest.fixture(scope="module")
+def omega():
+    return Ordinal(1)
+
+
+@pytest.fixture(scope="module")
+def omega_squared():
+    return Ordinal(2)
+
+
+@pytest.fixture(scope="module")
+def below(omega_squared):
+    """``x < y`` over ω², as a relation that takes ordinals as Python
+    values."""
+    x, y = omega_squared.symbolic().vars('x y')
+    return x.lt(y).evaluate()
+
+
+@pytest.fixture(scope="module")
+def successor(omega_squared):
+    """``y = x + 1`` over ω², likewise."""
+    x, y = omega_squared.symbolic().vars('x y')
+    return x.succ(y).evaluate()
+
+
+class TestCodec:
+    def test_roundtrip(self, omega_squared):
+        for value in [(0, 0), (0, 7), (1, 0), (3, 5), (12, 9)]:
+            assert omega_squared.decode(omega_squared.encode(value)) == value
+
+    def test_an_integer_is_the_finite_ordinal(self, omega_squared):
+        assert omega_squared.encode(5) == omega_squared.encode((0, 5))
+
+    def test_short_tuples_are_padded_with_leading_zeros(self):
+        w3 = Ordinal(3)
+        assert w3.encode((2, 5)) == w3.encode((0, 2, 5))
+
+    def test_too_many_coefficients_are_rejected(self, omega_squared):
+        with pytest.raises(ValueError, match="more than"):
+            omega_squared.encode((1, 2, 3))
+
+    def test_negative_coefficients_are_rejected(self, omega_squared):
+        with pytest.raises(ValueError, match="natural"):
+            omega_squared.encode((1, -2))
+
+
+class TestOrder:
+    """The order is reverse-lexicographic on the coefficients — checked
+    exhaustively against the Python tuple order on a finite window of ω²."""
+
+    def test_agrees_with_the_tuple_order(self, below):
+        window = list(itertools.product(range(3), range(4)))
+        for a, b in itertools.product(window, repeat=2):
+            assert below.contains(x=a, y=b) == (a < b), (a, b)
+
+    def test_the_finite_ordinals_sit_below_omega(self, below):
+        for finite in (0, 1, 7, 1000):
+            assert below.contains(x=finite, y=(1, 0))
+            assert not below.contains(x=(1, 0), y=finite)
+
+    def test_is_a_strict_total_order(self, omega, omega_squared):
+        assert omega.is_total_order()
+        assert omega_squared.is_total_order()
+
+
+class TestSuccessor:
+    def test_adds_one_to_the_constant_coefficient(self, successor):
+        assert successor.contains(x=(1, 3), y=(1, 4))
+        assert successor.contains(x=0, y=1)
+        assert not successor.contains(x=(1, 3), y=(1, 5))
+        # ω is a limit: it is nobody's successor, in particular not ω·0 + n
+        assert not successor.contains(x=(0, 7), y=(1, 0))
+
+    def test_symbolic_surface(self, omega_squared):
+        S = omega_squared.symbolic()
+        a, b = S.vars('a b')
+        assert a.succ(b).evaluate().contains(a=(2, 0), b=(2, 1))
+        assert a.lt(b).evaluate().contains(a=(0, 7), b=(1, 0))
+        assert a.eq(b).evaluate().contains(a=(1, 1), b=(1, 1))
+
+
+class TestOrdinalFacts:
+    """First-order facts that hold of ω^n and distinguish it from ℕ."""
+
+    def test_has_a_least_element_and_no_greatest(self, omega_squared):
+        assert omega_squared.check('exists x.(all y.(Lt(x,y) | Eq(x,y)))')
+        assert omega_squared.check('all x.(exists y.(Lt(x,y)))')
+
+    def test_omega_squared_has_limit_ordinals_but_omega_does_not(
+            self, omega, omega_squared):
+        # a limit is neither zero nor a successor
+        limit = ('exists x.((exists z.(Lt(z,x))) & '
+                 '(not exists y.(Succ(y,x))))')
+        assert not omega.check(limit)        # ℕ: every non-zero is a successor
+        assert omega_squared.check(limit)    # ω, ω·2, … are limits
+
+    def test_every_element_has_a_successor(self, omega_squared):
+        assert omega_squared.check('all x.(exists y.(Succ(x,y)))')
+
+    def test_the_order_is_discrete_upwards(self, omega_squared):
+        # the successor is the immediate one: nothing sits strictly between
+        assert omega_squared.check(
+            'all x.(all y.(Succ(x,y) -> '
+            '(not exists z.(Lt(x,z) & Lt(z,y)))))')
+
+
+class TestConstruction:
+    def test_exponent_must_be_positive(self):
+        with pytest.raises(ValueError, match=">= 1"):
+            Ordinal(0)
+
+    def test_repr(self, omega_squared):
+        assert repr(omega_squared) == "<Ordinal omega^2>"
+
+    def test_omega_is_the_naturals(self, omega):
+        # dimension 1: the interpretation is a definable reduct of ℕ, so the
+        # order relation is the source's own, minimized
+        from autstr.buildin.presentations import BuechiArithmetic
+        assert omega.presentation.automata['Lt'].num_states == \
+            BuechiArithmetic().automata['Lt'].num_states

--- a/tests/test_presentations.py
+++ b/tests/test_presentations.py
@@ -45,3 +45,56 @@ class TestRelationsLiveInTheUniverse:
                              relations={'Id': ('Eq(x,y)', ['x', 'y'])})
         assert naturals.check('all x. Id(x,x)')
         assert not naturals.check('exists x.(not Id(x,x))')
+
+
+def _same_language(one, other) -> bool:
+    """Language equality: the symmetric difference is empty."""
+    return (one.intersection(other.complement()).is_empty() and
+            other.intersection(one.complement()).is_empty())
+
+
+class TestSentencesUnderConnectives:
+    """A sentence has no free variables, so it evaluates to the all/none
+    marker rather than to a relation with tapes. Placing that marker into an
+    enclosing conjunction or disjunction used to be attempted as a tape
+    renaming, which raised `IndexError` — for two sentences there is no tape to
+    rename to at all.
+    """
+
+    def test_two_sentences_conjoined(self):
+        arithmetic = BuechiArithmetic()
+        true, false = 'all x.(Eq(x,x))', 'all x.(Lt(x,x))'
+        assert arithmetic.check(f'({true}) & ({true})')
+        assert not arithmetic.check(f'({true}) & ({false})')
+        assert not arithmetic.check(f'({false}) & ({true})')
+
+    def test_two_sentences_disjoined(self):
+        arithmetic = BuechiArithmetic()
+        true, false = 'all x.(Eq(x,x))', 'all x.(Lt(x,x))'
+        assert arithmetic.check(f'({false}) | ({true})')
+        assert not arithmetic.check(f'({false}) | ({false})')
+
+    def test_a_sentence_beside_an_open_formula(self):
+        """The sentence contributes its truth value and the open formula its
+        relation: a true conjunct must leave the relation alone, a false one
+        must empty it, and a true disjunct must fill it with the whole
+        universe."""
+        arithmetic = BuechiArithmetic()
+        true, false = 'all x.(Eq(x,x))', 'all x.(Lt(x,x))'
+
+        less = arithmetic.evaluate('Lt(y,z)')
+        assert _same_language(arithmetic.evaluate(f'({true}) & Lt(y,z)'), less)
+        assert arithmetic.evaluate(f'({false}) & Lt(y,z)').is_empty()
+
+        assert _same_language(arithmetic.evaluate(f'({true}) | Lt(y,z)'),
+                              arithmetic._domain_product(2))
+        assert _same_language(arithmetic.evaluate(f'({false}) | Lt(y,z)'), less)
+
+    def test_a_true_disjunct_does_not_admit_non_elements(self):
+        """The full relation of a structure is the product of its universes,
+        not every word: a true sentence disjoined with an open formula must
+        still reject encodings that are not elements."""
+        arithmetic = BuechiArithmetic()
+        filled = arithmetic.evaluate('(all x.(Eq(x,x))) | Lt(y,z)')
+        assert not filled.accepts([('0', '0'), ('0', '1')])   # '00' is not a
+        assert filled.accepts([('0', '0')])                   # well-formed 0

--- a/tests/test_presentations.py
+++ b/tests/test_presentations.py
@@ -6,10 +6,16 @@ engine relies on that — quantifiers restrict a bound variable to `U`, so an
 unrestricted relation makes a universal sentence look false on encodings that
 are not elements at all.
 """
+import itertools
+
+import pytest
+
+from autstr.buildin.automata import zero
 from autstr.buildin.presentations import (
     BuechiArithmetic, BuechiArithmeticZ, MSO0,
 )
 from autstr.interpretations import interpret
+from autstr.presentations import AutomaticPresentation
 
 
 def _leaks(presentation, name) -> bool:
@@ -53,48 +59,113 @@ def _same_language(one, other) -> bool:
             other.intersection(one.complement()).is_empty())
 
 
+#: a true and a false sentence over Buechi arithmetic
+TRUE, FALSE = 'all x.(Eq(x,x))', 'all x.(Lt(x,x))'
+
+#: the binary connectives, with their Python truth tables
+CONNECTIVES = {
+    '&': lambda a, b: a and b,
+    '|': lambda a, b: a or b,
+    '->': lambda a, b: (not a) or b,
+    '<->': lambda a, b: a == b,
+}
+
+
+def _convolution(a: int, b: int):
+    """The two-tape encoding of a pair of naturals, padded to equal length."""
+    wa, wb = list(format(a, 'b')[::-1]), list(format(b, 'b')[::-1])
+    n = max(len(wa), len(wb))
+    return list(zip(wa + ['*'] * (n - len(wa)), wb + ['*'] * (n - len(wb))))
+
+
 class TestSentencesUnderConnectives:
     """A sentence has no free variables, so it evaluates to the all/none
-    marker rather than to a relation with tapes. Placing that marker into an
-    enclosing conjunction or disjunction used to be attempted as a tape
-    renaming, which raised `IndexError` — for two sentences there is no tape to
-    rename to at all.
+    marker rather than to a relation with tapes: an arity-1 automaton that is
+    non-empty exactly when the sentence is true.
+
+    The marker is deliberately not the universe -- over an empty structure a
+    universal sentence is still vacuously true -- so placing it into an
+    enclosing formula is not a tape renaming. Attempting one raised IndexError,
+    and for two sentences there was no tape to rename to at all.
     """
 
-    def test_two_sentences_conjoined(self):
+    @pytest.mark.parametrize("connective", list(CONNECTIVES))
+    @pytest.mark.parametrize("left,right", list(itertools.product([True, False],
+                                                                 repeat=2)))
+    def test_two_sentences(self, connective, left, right):
         arithmetic = BuechiArithmetic()
-        true, false = 'all x.(Eq(x,x))', 'all x.(Lt(x,x))'
-        assert arithmetic.check(f'({true}) & ({true})')
-        assert not arithmetic.check(f'({true}) & ({false})')
-        assert not arithmetic.check(f'({false}) & ({true})')
+        phi = (f'({TRUE if left else FALSE}) {connective} '
+               f'({TRUE if right else FALSE})')
+        expected = CONNECTIVES[connective](left, right)
+        assert arithmetic.check(phi) == expected
+        assert arithmetic.check(f'not ({phi})') == (not expected)
 
-    def test_two_sentences_disjoined(self):
+    def test_sentences_nest(self):
         arithmetic = BuechiArithmetic()
-        true, false = 'all x.(Eq(x,x))', 'all x.(Lt(x,x))'
-        assert arithmetic.check(f'({false}) | ({true})')
-        assert not arithmetic.check(f'({false}) | ({false})')
+        assert arithmetic.check(f'(({TRUE}) | ({FALSE})) & (not ({FALSE}))')
+        assert arithmetic.check(
+            f'all y.((({TRUE}) & ({TRUE})) & Eq(y,y))')
+        assert not arithmetic.check(f'(all w.({TRUE})) & (exists w.({FALSE}))')
 
-    def test_a_sentence_beside_an_open_formula(self):
+    @pytest.mark.parametrize("connective", list(CONNECTIVES))
+    @pytest.mark.parametrize("truth", [True, False])
+    @pytest.mark.parametrize("first", [True, False])
+    def test_a_sentence_beside_an_open_formula(self, connective, truth, first):
         """The sentence contributes its truth value and the open formula its
-        relation: a true conjunct must leave the relation alone, a false one
-        must empty it, and a true disjunct must fill it with the whole
-        universe."""
+        relation, on either side of the connective."""
         arithmetic = BuechiArithmetic()
-        true, false = 'all x.(Eq(x,x))', 'all x.(Lt(x,x))'
+        sentence = TRUE if truth else FALSE
+        phi = (f'({sentence}) {connective} Lt(y,z)' if first
+               else f'Lt(y,z) {connective} ({sentence})')
+        relation = arithmetic.evaluate(phi)
 
-        less = arithmetic.evaluate('Lt(y,z)')
-        assert _same_language(arithmetic.evaluate(f'({true}) & Lt(y,z)'), less)
-        assert arithmetic.evaluate(f'({false}) & Lt(y,z)').is_empty()
+        for a, b in itertools.product(range(4), repeat=2):
+            expected = (CONNECTIVES[connective](truth, a < b) if first
+                        else CONNECTIVES[connective](a < b, truth))
+            assert relation.accepts(_convolution(a, b)) == expected, (a, b)
 
-        assert _same_language(arithmetic.evaluate(f'({true}) | Lt(y,z)'),
-                              arithmetic._domain_product(2))
-        assert _same_language(arithmetic.evaluate(f'({false}) | Lt(y,z)'), less)
-
-    def test_a_true_disjunct_does_not_admit_non_elements(self):
-        """The full relation of a structure is the product of its universes,
-        not every word: a true sentence disjoined with an open formula must
-        still reject encodings that are not elements."""
+    def test_a_true_operand_is_the_universe_not_every_word(self):
+        """A subformula's automaton is a relation over the universe. The
+        marker is not -- it accepts every word -- so a true sentence beside an
+        open formula must contribute the product of universes instead, or the
+        result admits encodings that are not elements."""
         arithmetic = BuechiArithmetic()
-        filled = arithmetic.evaluate('(all x.(Eq(x,x))) | Lt(y,z)')
+        filled = arithmetic.evaluate(f'({TRUE}) | Lt(y,z)')
         assert not filled.accepts([('0', '0'), ('0', '1')])   # '00' is not a
         assert filled.accepts([('0', '0')])                   # well-formed 0
+        assert _same_language(filled, arithmetic._domain_product(2))
+
+        kept = arithmetic.evaluate(f'({TRUE}) & Lt(y,z)')
+        assert _same_language(kept, arithmetic.evaluate('Lt(y,z)'))
+        assert arithmetic.evaluate(f'({FALSE}) & Lt(y,z)').is_empty()
+
+
+class TestSentencesOverAnEmptyUniverse:
+    """The degenerate case the marker convention exists for: over an empty
+    structure every universal sentence is vacuously true, which is why a true
+    sentence is the all-marker and not the universe. An open formula beside it
+    still collapses, since every relation over an empty universe is empty.
+    """
+
+    @staticmethod
+    def _empty():
+        sigma = {'0', '1', '*'}
+        return AutomaticPresentation(
+            {'U': zero(1, sigma), 'Eq': zero(2, sigma), 'Lt': zero(2, sigma)},
+            padding_symbol='*')
+
+    def test_a_universal_sentence_is_vacuously_true(self):
+        assert self._empty().check('all x.(Lt(x,x))')
+
+    def test_an_existential_sentence_is_false(self):
+        assert not self._empty().check('exists x.(Eq(x,x))')
+
+    def test_vacuous_truth_survives_a_connective(self):
+        empty = self._empty()
+        assert empty.check('(all x.(Lt(x,x))) & (all x.(Lt(x,x)))')
+        assert empty.check('(all x.(Lt(x,x))) | (exists x.(Eq(x,x)))')
+        assert not empty.check('(all x.(Lt(x,x))) & (exists x.(Eq(x,x)))')
+
+    def test_an_open_formula_beside_it_is_still_empty(self):
+        empty = self._empty()
+        assert empty.evaluate('(all x.(Lt(x,x))) | Lt(y,z)').is_empty()

--- a/tests/test_regular_tree.py
+++ b/tests/test_regular_tree.py
@@ -1,0 +1,130 @@
+"""The infinite k-ary tree with its successors and prefix order.
+
+The oracle is Python's own word operations: a vertex is a tuple of child
+indices, ``y = x·i`` is a tuple append, and the prefix order is a slice
+comparison. Every relation is checked exhaustively against those over the
+vertices of depth ≤ 3.
+"""
+import itertools
+
+import pytest
+
+from autstr.infinite_graphs import RegularTree
+
+
+@pytest.fixture(scope="module")
+def binary():
+    return RegularTree(2)
+
+
+def vertices(k: int, depth: int):
+    """Every vertex of depth at most `depth`, as a tuple of child indices."""
+    return [word
+            for length in range(depth + 1)
+            for word in itertools.product(range(k), repeat=length)]
+
+
+class TestCodec:
+    def test_roundtrip(self, binary):
+        for vertex in vertices(2, 3):
+            assert binary.decode(binary.encode(vertex)) == vertex
+
+    def test_the_root_is_the_empty_word(self, binary):
+        assert binary.encode(()) == []
+
+    def test_a_string_of_digits_is_accepted(self, binary):
+        assert binary.encode('011') == binary.encode((0, 1, 1))
+
+    def test_an_index_outside_the_branching_is_rejected(self, binary):
+        with pytest.raises(ValueError, match="child index"):
+            binary.encode((0, 2))
+
+
+class TestSuccessors:
+    def test_each_successor_appends_its_letter(self, binary):
+        S = binary.symbolic()
+        x, y = S.vars('x y')
+        for i in range(2):
+            relation = S.rel(f'S{i}')(x, y).evaluate()
+            for a, b in itertools.product(vertices(2, 3), repeat=2):
+                expected = (b == a + (i,))
+                assert relation.contains(x=a, y=b) == expected, (i, a, b)
+
+    def test_child_is_the_union_of_the_successors(self, binary):
+        S = binary.symbolic()
+        x, y = S.vars('x y')
+        relation = S.rel('Child')(x, y).evaluate()
+        for a, b in itertools.product(vertices(2, 3), repeat=2):
+            assert relation.contains(x=a, y=b) == (b[:-1] == a and len(b) > 0)
+
+
+class TestPrefixOrder:
+    def test_agrees_with_the_slice_comparison(self, binary):
+        S = binary.symbolic()
+        x, y = S.vars('x y')
+        relation = S.rel('Prefix')(x, y).evaluate()
+        for a, b in itertools.product(vertices(2, 3), repeat=2):
+            assert relation.contains(x=a, y=b) == (b[:len(a)] == a), (a, b)
+
+    def test_is_a_partial_order_with_a_least_element(self, binary):
+        assert binary.check('all x.(Prefix(x,x))')
+        assert binary.check('all x.(all y.((Prefix(x,y) & Prefix(y,x)) '
+                            '-> Eq(x,y)))')
+        assert binary.check('exists r.(all x.(Prefix(r,x)))')     # the root
+
+
+class TestGraph:
+    def test_the_edge_is_the_parent_child_relation(self, binary):
+        S = binary.symbolic()
+        x, y = S.vars('x y')
+        edge = x.adj(y).evaluate()
+        assert edge.contains(x=(), y=(0,))
+        assert edge.contains(x=(0,), y=())            # undirected
+        assert edge.contains(x=(0, 1), y=(0, 1, 0))
+        assert not edge.contains(x=(), y=(0, 1))      # not a grandchild
+        assert not edge.contains(x=(0,), y=(1,))      # not siblings
+        assert not edge.contains(x=(0,), y=(0,))      # no self-loop
+
+    def test_is_symmetric(self, binary):
+        assert binary.is_symmetric()
+
+    def test_every_vertex_but_the_root_has_exactly_one_parent(self, binary):
+        assert binary.check(
+            'all y.((exists p.(Child(p,y))) -> '
+            'all p.(all q.((Child(p,y) & Child(q,y)) -> Eq(p,q))))')
+        # the root is the one vertex without a parent, and it is unique
+        assert binary.check(
+            'exists r.((not exists p.(Child(p,r))) & '
+            'all x.((not exists p.(Child(p,x))) -> Eq(x,r)))')
+
+    def test_every_vertex_has_a_child_for_each_letter(self, binary):
+        for i in range(2):
+            assert binary.check(f'all x.(exists y.(S{i}(x,y)))')
+
+    def test_distinct_letters_give_distinct_children(self, binary):
+        assert binary.check(
+            'all x.(all y.(all z.((S0(x,y) & S1(x,z)) -> (not Eq(y,z)))))')
+
+
+class TestConstruction:
+    def test_branching_must_be_positive(self):
+        with pytest.raises(ValueError, match=">= 1"):
+            RegularTree(0)
+
+    def test_repr(self, binary):
+        assert repr(binary) == "<RegularTree branching=2>"
+
+    def test_a_ray_is_the_one_ary_tree(self):
+        ray = RegularTree(1)
+        # exactly one child each: the tree degenerates to a chain
+        assert ray.check('all x.(exists y.(S0(x,y)))')
+        assert ray.check('all x.(all y.(all z.((Child(x,y) & Child(x,z)) '
+                         '-> Eq(y,z))))')
+
+    def test_a_wider_tree(self):
+        wide = RegularTree(4)
+        assert sorted(s for s in wide.get_relation_symbols()
+                      if s.startswith('S')) == ['S0', 'S1', 'S2', 'S3']
+        S = wide.symbolic()
+        x, y = S.vars('x y')
+        assert x.adj(y).evaluate().contains(x=(3,), y=(3, 2))

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -6,6 +6,7 @@ import pytest
 from autstr.buildin.presentations import BuechiArithmeticZ
 from autstr.symbolic import (
     CompileError, FunctionCodec, Signature, SymbolicSymbolError,
+    graph_signature, order_signature, relational_signature,
 )
 
 
@@ -466,3 +467,50 @@ def test_failed_evaluation_does_not_leave_spliced_relations_installed(S):
 
     assert dict(presentation.automata) == before
     assert 'Spliced' not in presentation.automata
+
+
+# ----------------------------------------------------------------------
+# signature constructors
+# ----------------------------------------------------------------------
+
+def test_relational_signature_binds_every_method():
+    signature = relational_signature({'Lt', 'Eq', 'Div'},
+                                     {'lt': 'Lt', 'divides': 'Div'})
+    assert signature.operators == {'lt': 'Lt', 'divides': 'Div', 'eq': 'Eq'}
+    assert signature.functions == {}          # a relational structure has none
+
+
+def test_relational_signature_omits_an_absent_equality():
+    signature = relational_signature({'Lt'}, {'lt': 'Lt'})
+    assert 'eq' not in signature.operators
+
+
+def test_relational_signature_binds_a_method_whose_symbol_is_absent():
+    """A requested method is bound whether or not the structure declares it,
+    so a typo fails loudly at compile time rather than going silently
+    unbound."""
+    signature = relational_signature({'Lt'}, {'lt': 'Ltt'})
+    assert signature.operators['lt'] == 'Ltt'
+
+
+def test_order_signature_binds_the_order_and_extra_methods():
+    signature = order_signature({'Lt', 'Eq', 'Succ'}, less='Lt',
+                                methods={'succ': 'Succ'})
+    assert signature.operators == {'lt': 'Lt', 'succ': 'Succ', 'eq': 'Eq'}
+
+
+def test_order_signature_renames_the_method():
+    signature = order_signature({'Below', 'Eq'}, less='Below', order='below')
+    assert signature.operators['below'] == 'Below'
+    assert 'lt' not in signature.operators
+
+
+def test_graph_signature_binds_adjacency():
+    signature = graph_signature({'E', 'Eq'})
+    assert signature.operators == {'adj': 'E', 'eq': 'Eq'}
+
+
+def test_a_signature_carries_its_codec():
+    codec = FunctionCodec(_encode, _decode)
+    assert order_signature({'Lt'}, codec=codec).codec is codec
+    assert graph_signature({'E'}, codec=codec).codec is codec

--- a/tests/test_turing.py
+++ b/tests/test_turing.py
@@ -1,0 +1,165 @@
+"""Turing-machine configuration graphs.
+
+The oracle is the machine itself: `TuringMachine.step` runs one step in Python,
+and the edge relation must agree with it on every pair of configurations up to
+a bounded tape length. Three machines exercise the three directions, including
+the two cases where the encoding changes length — a right move off the written
+tape, and a left move that writes a blank into the last cell.
+"""
+import itertools
+
+import pytest
+
+from autstr.turing import Configuration, TuringMachine
+
+
+#: walks right over 1s, writes a 1 into the first blank and stops
+SCANNER = TuringMachine({('q', '1'): ('q', '1', 'R'),
+                         ('q', '_'): ('h', '1', 'S')}, blank='_')
+
+#: walks left erasing as it goes — the encoding shrinks at every step
+ERASER = TuringMachine({('q', '1'): ('q', '_', 'L'),
+                        ('q', '_'): ('q', '_', 'L')}, blank='_')
+
+#: flips a bit in place, then moves right; two states, two symbols
+FLIPPER = TuringMachine({('a', '0'): ('b', '1', 'R'),
+                         ('a', '1'): ('b', '0', 'R'),
+                         ('b', '0'): ('a', '0', 'L'),
+                         ('b', '1'): ('a', '1', 'L')}, blank='0')
+
+
+def configurations(machine, length: int):
+    """Every canonical configuration with a tape of at most `length` cells."""
+    found = []
+    for size in range(1, length + 1):
+        for tape in itertools.product(machine.tape_alphabet, repeat=size):
+            for head in range(size):
+                for state in machine.states:
+                    configuration = Configuration(state, tape, head)
+                    if machine.canonical(configuration) == configuration:
+                        found.append(configuration)
+    return found
+
+
+@pytest.fixture(scope="module")
+def scanner_graph():
+    return SCANNER.configuration_graph()
+
+
+class TestMachine:
+    def test_step_runs_the_machine(self):
+        run = list(SCANNER.run(Configuration('q', ('1', '1'), 0)))
+        assert run[-1] == Configuration('h', ('1', '1', '1'), 2)
+
+    def test_a_missing_transition_halts(self):
+        assert SCANNER.step(Configuration('h', ('1',), 0)) is None
+
+    def test_a_left_move_off_the_tape_halts(self):
+        assert ERASER.step(Configuration('q', ('1',), 0)) is None
+
+    def test_trailing_blanks_are_dropped(self):
+        canonical = SCANNER.canonical(Configuration('q', ('1', '_', '_'), 0))
+        assert canonical == Configuration('q', ('1',), 0)
+
+    def test_the_head_cell_is_never_dropped(self):
+        configuration = Configuration('q', ('1', '_'), 1)
+        assert SCANNER.canonical(configuration) == configuration
+
+    def test_an_unknown_direction_is_rejected(self):
+        with pytest.raises(ValueError, match="not a direction"):
+            TuringMachine({('q', '1'): ('q', '1', 'up')})
+
+    def test_the_padding_symbol_is_reserved(self):
+        with pytest.raises(ValueError, match="reserved"):
+            TuringMachine({('q', '*'): ('q', '*', 'R')})
+
+    def test_the_head_is_on_the_tape(self):
+        with pytest.raises(ValueError, match="off a tape"):
+            Configuration('q', ('1',), 3)
+
+
+class TestCodec:
+    def test_roundtrip(self):
+        for configuration in configurations(SCANNER, 3):
+            assert SCANNER.decode(SCANNER.encode(configuration)) == configuration
+
+    def test_the_word_marks_the_head_cell(self):
+        assert SCANNER.encode(Configuration('q', ('1', '_'), 1)) == ['1', 'q|_']
+
+    def test_a_word_without_a_head_is_no_configuration(self):
+        with pytest.raises(ValueError, match="no head"):
+            SCANNER.decode(['1', '1'])
+
+
+class TestStepRelation:
+    """The edge relation, checked exhaustively against the Python oracle."""
+
+    @pytest.mark.parametrize("machine", [SCANNER, ERASER, FLIPPER],
+                             ids=['scanner', 'eraser', 'flipper'])
+    def test_agrees_with_the_oracle(self, machine):
+        graph = machine.configuration_graph()
+        x, y = graph.symbolic().vars('x y')
+        edge = x.adj(y).evaluate()
+
+        space = configurations(machine, 3)
+        for source in space:
+            successor = machine.step(source)
+            for target in space:
+                assert edge.contains(x=source, y=target) == \
+                    (successor == target), (source, target)
+
+    def test_the_tape_may_grow(self, scanner_graph):
+        x, y = scanner_graph.symbolic().vars('x y')
+        edge = x.adj(y).evaluate()
+        # the head steps off the written tape, and the word gains a cell
+        assert edge.contains(x=Configuration('q', ('1',), 0),
+                             y=Configuration('q', ('1', '_'), 1))
+
+    def test_the_tape_may_shrink(self):
+        graph = ERASER.configuration_graph()
+        x, y = graph.symbolic().vars('x y')
+        edge = x.adj(y).evaluate()
+        # erasing the last cell drops it from the encoding
+        assert edge.contains(x=Configuration('q', ('1', '1'), 1),
+                             y=Configuration('q', ('1',), 0))
+
+
+class TestFirstOrderTheory:
+    def test_the_machine_is_deterministic(self, scanner_graph):
+        assert scanner_graph.is_deterministic()
+
+    def test_halting_configurations_are_definable(self, scanner_graph):
+        S = scanner_graph.symbolic()
+        halting = S.rel('Halt')(S.vars('x')[0]).evaluate()
+        assert halting.contains(x=Configuration('h', ('1',), 0))
+        assert not halting.contains(x=Configuration('q', ('1',), 0))
+
+    def test_a_stuck_left_move_halts(self):
+        graph = ERASER.configuration_graph()
+        S = graph.symbolic()
+        halting = S.rel('Halt')(S.vars('x')[0]).evaluate()
+        # the head cannot leave cell 0, so this configuration has no successor
+        assert halting.contains(x=Configuration('q', ('1',), 0))
+        assert not halting.contains(x=Configuration('q', ('1', '1'), 1))
+
+    def test_some_configuration_halts_and_some_does_not(self, scanner_graph):
+        assert scanner_graph.check('exists x.(Halt(x))')
+        assert scanner_graph.check('exists x.(not Halt(x))')
+
+    def test_every_configuration_has_at_most_one_successor(self):
+        assert FLIPPER.configuration_graph().is_deterministic()
+
+
+class TestTheBoundary:
+    """Reachability is the halting problem, so it is not first-order over this
+    graph and the construction does not offer it. What is offered is exactly
+    what the engine can decide."""
+
+    def test_no_reachability_relation_is_provided(self, scanner_graph):
+        assert sorted(scanner_graph.get_relation_symbols()) == \
+            ['E', 'Eq', 'Halt', 'U']
+
+    def test_one_step_reachability_is_fine(self, scanner_graph):
+        # bounded step counts stay first-order: they are just nested edges
+        assert scanner_graph.check(
+            'exists x.(exists y.(exists z.(E(x,y) & E(y,z) & Halt(z))))')


### PR DESCRIPTION
Tier I of the infinite-structures phase, on top of the foundation merged in #38:
the ordinals, the regular tree, and Turing-machine configuration graphs — plus
the signature vocabulary they needed and an engine fix found while building them.

## The structures

**`Ordinal(n)` — the ordinals below ω^n** (`autstr/ordinals.py`). Delhommé's
theorem puts the word-automatic ordinals exactly at those below ω^ω, and every
one of them lives in some ω^n, so this covers all of them and the string engine
goes no further.

It is *derived, not authored*. By Cantor normal form an ordinal below ω^n is a
tuple of n natural coefficients, so ω^n is an n-dimensional first-order
interpretation of Büchi arithmetic — the order reverse-lexicographic on the
coefficients, the successor an addition in the constant one. The whole factory
is three formulas and no automaton. This is `interpret` earning its keep.

```python
W2 = Ordinal(2)
a, b = W2.symbolic().vars("a b")
a.lt(b).evaluate().contains(a=(0, 7), b=(1, 0))     # 7 < ω  -> True
W2.check('exists x.((exists z.(Lt(z,x))) & (not exists y.(Succ(y,x))))')
```

Ordinals are written as coefficient tuples in descending exponent order, which
compare lexicographically exactly as the ordinals do — so Python is the oracle
the tests check the automata against.

**`RegularTree(k)` — the infinite k-ary tree** (`autstr/infinite_graphs.py`).
Vertices are the words over `{0..k-1}`, so the tree is its own encoding and
every relation is a small automaton read straight off the word operations:
`S0…S{k-1}`, their union `Child`, the prefix order, and the undirected edge.
The substrate the later tiers stand on, and the Cayley graph of the free monoid
on k generators.

**`TuringMachine` / `ConfigurationGraph`** (`autstr/turing.py`). A configuration
is a word — the tape, with the cell under the head naming both the state and
what is written there — and one step rewrites it locally, so the step relation
is a synchronous automaton whose size depends on the transition table alone.
Determinism, halting configurations and bounded step counts are all decidable
and all askable.

**Reachability is deliberately absent.** It is the halting problem, so it is not
first-order over this graph and no construction here can supply it: an automatic
presentation with a decidable theory still cannot express the one question you
would most like to ask. `Halt` is what can be had, and it is defined from the
edge rather than authored.

The tape is one-way infinite and trailing blanks are dropped, so each
configuration has exactly one word and a step changes that word's length by at
most one cell, at the right end — which is what keeps the relation synchronous.

## Supporting work

- **`relational_signature` / `order_signature`** (`autstr/symbolic/signature.py`).
  An order is not a graph: `x.lt(y)` and `x.adj(y)` read differently even where
  both are binary. `graph_signature` is now a call to `relational_signature`,
  which binds any set of relation methods.
- **`automata_tools.partial_dfa`** — a DFA from a *partial* transition table,
  everything unlisted going to a sink. Authoring an automaton over a product
  alphabet otherwise costs |Σ|^k entries per state to repeatedly say "reject".
- **Engine fix: sentences as operands of `&` / `|`.** A subformula with no free
  variables evaluates to the all/none marker, whose single tape is a placeholder
  rather than a variable. Both branches renamed their operands' tapes into the
  enclosing formula's order, which is meaningless for a marker and, for two
  sentences, impossible — `(all x. φ) & (all y. ψ)` raised `IndexError`.
  `_operand_automaton` remakes a sentence at the enclosing arity instead: false
  becomes the empty relation, true the product of universes, not every word, so
  a true disjunct still admits no non-elements.

  The marker convention itself is sound and stays: it is an arity-1 automaton
  that is non-empty exactly when the sentence is true, and it is deliberately
  *not* the universe, because over an empty structure a universal sentence is
  still vacuously true. Both properties are now pinned by tests, along with all
  four connectives against their truth tables on both operand orders.

## Testing

Full suite green: **580 passed, 5 skipped** (512 before this branch). Every
structure is checked against a Python oracle — ordinals against tuple
lexicographic order, the tree against word operations, and each Turing-machine
edge against `TuringMachine.step`, exhaustively over three machines covering
left, right and stay moves and both cases where the encoding changes length.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
