### PR TITLE
Tier II foundation: interpretations over the tree engine, and the tree-automatic ordinals

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ batch:
 |---------|------------|
 | `autstr.arithmetic`, `autstr.buildin` | Presburger and Büchi arithmetic (ℤ, +, <, \|₂), Skolem arithmetic (ℕ, ·), the MSO0 finite-powerset structure |
 | `autstr.algebra` | the localizations **ℤ[1/p]**, finite **Boolean algebras** |
-| `autstr.infinite_graphs`, `autstr.ordinals`, `autstr.turing` | the **integer grid** ℤⁿ, the **regular tree** T_k, the **ordinals** below ω^ω, **Turing-machine configuration graphs** |
+| `autstr.infinite_graphs`, `autstr.ordinals`, `autstr.turing` | the **integer grid** ℤⁿ, the **regular tree** T_k, the **ordinals** below ω^ω and — on the tree engine — below ω^(ω^ω), **Turing-machine configuration graphs** |
 
 **Classes** — one automaton for a whole family, indexed by advice:
 

--- a/autstr/interpretations.py
+++ b/autstr/interpretations.py
@@ -24,24 +24,74 @@ symbol-width overhead, intrinsic to representing tuples.
 Quotient interpretations (elements as classes of a definable equivalence) are
 supported at every dimension: pass ``quotient=ε``, and the universe is
 restricted to the shortlex-least representative of each class.
+
+**Both engines.** The source may be an `AutomaticPresentation` or a
+`TreeAutomaticPresentation`, and the result is a presentation of the same kind;
+the orchestration is identical because both engines encode a convolution letter
+the same way. Over trees an element of a k-dimensional interpretation is a
+k-tuple of trees, which *is* one tree over k-tuples — the same fold, since the
+tree convolution already overlays the shapes. The one thing the tree engine
+cannot do is choose quotient representatives: that needs a well-order on
+encodings, and shortlex has no tree counterpart. Name the representatives with
+a formula and restrict the domain instead; `_quotient` says why in full.
 """
 from __future__ import annotations
 
-from typing import Dict, Optional, Sequence, Tuple, Union
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 from nltk.sem import logic
 
 from autstr.presentations import AutomaticPresentation
-from autstr.sparse_automata import SparseDFA
-from autstr.utils.automata_tools import (
-    fold_tapes, permute_tapes, shortlex_order,
-)
 from autstr.utils.logic import get_free_elementary_vars
 
 #: scaffolding relations a quotient interpretation installs on the intermediate
 #: structure and drops from the result
 _EQUIV = '_Equiv'
 _LE = '_Le'
+
+@dataclass(frozen=True)
+class _Engine:
+    """The tape machinery of whichever engine the source belongs to.
+
+    Interpreting is the same orchestration over words and over trees — evaluate
+    the formulas, order their tapes, fold every k into one element tape — and
+    the operations differ only in which automaton type they act on. Both
+    engines encode a symbol the same way (an MTBDD over the binary digits of
+    the convolution letter, tape-major), which is why the fold is literally the
+    same diagram surgery on either side.
+    """
+    name: str
+    permute_tapes: Callable
+    fold_tapes: Callable
+    presentation: Callable
+    #: a well-order on encodings, or None where the engine has none — the
+    #: quotient construction needs one to pick class representatives
+    well_order: Optional[Callable]
+
+
+def _engine_for(source) -> _Engine:
+    from autstr.tree_presentations import TreeAutomaticPresentation
+    if isinstance(source, TreeAutomaticPresentation):
+        from autstr.utils import tree_automata_tools as trees
+        return _Engine(
+            name='tree',
+            permute_tapes=trees.permute_tapes,
+            fold_tapes=trees.fold_tapes,
+            presentation=lambda automata, padding: TreeAutomaticPresentation(
+                automata, padding_symbol=padding,
+                max_states=source.max_states),
+            well_order=None)
+
+    from autstr.utils import automata_tools as words
+    return _Engine(
+        name='string',
+        permute_tapes=words.permute_tapes,
+        fold_tapes=words.fold_tapes,
+        presentation=lambda automata, padding: AutomaticPresentation(
+            automata, padding_symbol=padding),
+        well_order=words.shortlex_order)
+
 
 Formula = Union[str, logic.Expression]
 #: a relation is a formula, or a ``(formula, coordinate-order)`` pair; the
@@ -50,13 +100,15 @@ Formula = Union[str, logic.Expression]
 RelationSpec = Union[Formula, Tuple[Formula, Sequence[str]]]
 
 
-def interpret(source: AutomaticPresentation, domain: RelationSpec,
+def interpret(source, domain: RelationSpec,
               relations: Dict[str, RelationSpec],
               dimension: int = 1,
-              quotient: Optional[RelationSpec] = None) -> AutomaticPresentation:
+              quotient: Optional[RelationSpec] = None):
     """The first-order interpretation of a structure in `source`.
 
-    :param source: the structure to interpret in.
+    :param source: the structure to interpret in — an `AutomaticPresentation`
+        or a `TreeAutomaticPresentation`. The result is a presentation of the
+        same kind.
     :param domain: the domain formula δ(x̄) with ``dimension`` free variables —
         the coordinates of one element; the new universe is the tuples
         satisfying it. A ``(formula, coordinate-order)`` pair fixes which free
@@ -71,37 +123,41 @@ def interpret(source: AutomaticPresentation, domain: RelationSpec,
         are its equivalence classes: the universe is restricted to the
         shortlex-least representative of each class, and the relations are read
         on those representatives. The caller must ensure ε really is an
-        equivalence and that every relation is ε-invariant.
-    :return: a fresh `AutomaticPresentation`. For k > 1 its alphabet is the
-        source alphabet's k-fold product.
+        equivalence and that every relation is ε-invariant. **String engine
+        only** — see `_quotient` for why, and for what to write instead over
+        trees.
+    :return: a fresh presentation of the same kind as `source`. For k > 1 its
+        alphabet is the source alphabet's k-fold product.
     """
     if dimension < 1:
         raise ValueError("dimension must be >= 1")
+    engine = _engine_for(source)
     if quotient is not None:
-        return _quotient(source, domain, relations, dimension, quotient)
+        return _quotient(source, domain, relations, dimension, quotient,
+                         engine)
     k = dimension
 
-    universe = _fold_formula(source, domain, k)
+    universe = _fold_formula(source, domain, k, engine)
     if universe.symbol_arity != 1:
         raise ValueError(
             f"the domain formula must have {k} free variable(s) — the "
             f"coordinates of one element — but defines "
             f"{universe.symbol_arity} element(s)")
 
-    automata: Dict[str, SparseDFA] = {'U': universe}
+    automata = {'U': universe}
     for name, spec in relations.items():
         if name == 'U':
             raise ValueError("'U' is the reserved universe symbol")
-        automata[name] = _fold_formula(source, spec, k)
+        automata[name] = _fold_formula(source, spec, k, engine)
 
     padding = source.padding_symbol if k == 1 \
         else (source.padding_symbol,) * k
-    return AutomaticPresentation(automata, padding_symbol=padding)
+    return engine.presentation(automata, padding)
 
 
-def _quotient(source: AutomaticPresentation, domain: RelationSpec,
+def _quotient(source, domain: RelationSpec,
               relations: Dict[str, RelationSpec], dimension: int,
-              equivalence: RelationSpec) -> AutomaticPresentation:
+              equivalence: RelationSpec, engine: _Engine):
     """Interpret with a quotient, in two stages: first the plain (k-dim)
     interpretation carrying the equivalence as a relation, then a
     one-dimensional interpretation restricting the universe to the
@@ -111,13 +167,31 @@ def _quotient(source: AutomaticPresentation, domain: RelationSpec,
     shortlex well-order on the element encoding — ``x`` is canonical iff it is
     ``<=`` every element equivalent to it — so the whole thing stays inside the
     engine.
+
+    That last step is what the tree engine cannot supply. Picking a
+    representative needs a **well-order** on encodings, and shortlex works over
+    words because the convolution aligns positions, which makes comparing
+    lengths free. A tree convolution aligns *shapes*, so a bottom-up automaton
+    cannot compare two trees\' sizes at all, and every order it can decide is
+    settled by a finite-state summary — which the usual trick of pushing the
+    difference deeper turns into an infinite descending chain. So a caller who
+    wants a quotient over trees names the representatives instead: pick a
+    formula ρ(x̄) true of exactly one element per class and interpret with
+    ``domain=δ ∧ ρ``, which is the same construction with the choice made
+    explicit.
     """
+    if engine.well_order is None:
+        raise NotImplementedError(
+            f"the {engine.name} engine has no well-order on encodings, so a "
+            f"quotient cannot pick class representatives; restrict the domain "
+            f"to a definable set of representatives instead (see the "
+            f"documentation of this construction)")
     if _EQUIV in relations or _LE in relations:
         raise ValueError(f"{_EQUIV!r} and {_LE!r} are reserved for the "
                          f"quotient construction")
     raw = interpret(source, domain, {**relations, _EQUIV: equivalence},
                     dimension)
-    raw.update(**{_LE: shortlex_order(raw.sigma, raw.padding_symbol)})
+    raw.update(**{_LE: engine.well_order(raw.sigma, raw.padding_symbol)})
 
     representative = f'all y.({_EQUIV}(x,y) -> {_LE}(x,y))'
     specs: Dict[str, RelationSpec] = {}
@@ -128,8 +202,7 @@ def _quotient(source: AutomaticPresentation, domain: RelationSpec,
     return interpret(raw, (representative, ['x']), specs)
 
 
-def _fold_formula(source: AutomaticPresentation, spec: RelationSpec,
-                  k: int) -> SparseDFA:
+def _fold_formula(source, spec: RelationSpec, k: int, engine: _Engine):
     """Evaluate a formula over `source`, order its tapes coordinate-major, and
     fold every k of them into one element tape."""
     formula, order = spec if isinstance(spec, tuple) else (spec, None)
@@ -150,5 +223,5 @@ def _fold_formula(source: AutomaticPresentation, spec: RelationSpec,
 
     permutation = [free.index(v) for v in order]
     if permutation != list(range(len(order))):
-        dfa = permute_tapes(dfa, permutation)
-    return fold_tapes(dfa, k) if k > 1 else dfa
+        dfa = engine.permute_tapes(dfa, permutation)
+    return engine.fold_tapes(dfa, k) if k > 1 else dfa

--- a/autstr/interpretations.py
+++ b/autstr/interpretations.py
@@ -30,10 +30,12 @@ restricted to the shortlex-least representative of each class.
 the orchestration is identical because both engines encode a convolution letter
 the same way. Over trees an element of a k-dimensional interpretation is a
 k-tuple of trees, which *is* one tree over k-tuples — the same fold, since the
-tree convolution already overlays the shapes. The one thing the tree engine
-cannot do is choose quotient representatives: that needs a well-order on
-encodings, and shortlex has no tree counterpart. Name the representatives with
-a formula and restrict the domain instead; `_quotient` says why in full.
+tree convolution already overlays the shapes. Quotients are the exception: over
+trees the representatives exist and are regular, but reaching them takes a
+different construction from the string engine's "least element of the class",
+because no tree-automatic order is well-founded. Name the representatives with
+a formula and restrict the domain instead; `_quotient` says why in full, with
+the reference for building them properly.
 """
 from __future__ import annotations
 
@@ -124,8 +126,8 @@ def interpret(source, domain: RelationSpec,
         shortlex-least representative of each class, and the relations are read
         on those representatives. The caller must ensure ε really is an
         equivalence and that every relation is ε-invariant. **String engine
-        only** — see `_quotient` for why, and for what to write instead over
-        trees.
+        only so far** — see `_quotient` for what the tree engine would need,
+        and for what to write instead meanwhile.
     :return: a fresh presentation of the same kind as `source`. For k > 1 its
         alphabet is the source alphabet's k-fold product.
     """
@@ -168,24 +170,46 @@ def _quotient(source, domain: RelationSpec,
     ``<=`` every element equivalent to it — so the whole thing stays inside the
     engine.
 
-    That last step is what the tree engine cannot supply. Picking a
-    representative needs a **well-order** on encodings, and shortlex works over
-    words because the convolution aligns positions, which makes comparing
-    lengths free. A tree convolution aligns *shapes*, so a bottom-up automaton
-    cannot compare two trees\' sizes at all, and every order it can decide is
-    settled by a finite-state summary — which the usual trick of pushing the
-    difference deeper turns into an infinite descending chain. So a caller who
-    wants a quotient over trees names the representatives instead: pick a
-    formula ρ(x̄) true of exactly one element per class and interpret with
-    ``domain=δ ∧ ρ``, which is the same construction with the choice made
-    explicit.
+    That last step is what the tree engine does not have. It is *not* that
+    representatives fail to exist: every tree-automatic equivalence has a
+    regular complete system of representatives (Colcombet & Löding 2007), and
+    one is computable in polynomial space with ``2^O(|A|)`` states (Kuske &
+    Weidner, *Size and computation of injective tree automatic presentations*,
+    MFCS 2011, Thm. 3.1). What fails is *this* way of getting them.
+
+    Taking the least element of a class needs a well-founded order, and the
+    tree-automatic order does not qualify. There is a tree-automatic linear
+    order — compare at the lexicographically least position where two trees
+    differ, counting an absent position as larger — but growing a tree at that
+    position makes it *smaller*, so an infinite descending chain is easy to
+    write down and a class need have no least element. Shortlex avoids this
+    over words only because the convolution aligns positions, which makes
+    length the primary key for free; a tree convolution aligns shapes instead,
+    and comparing two trees' sizes is not a finite-state property at all.
+
+    Kuske and Weidner get round it by not minimizing over the whole class.
+    Their *shadow* of a class is the set of positions present in every member,
+    and a *description* is a member whose subtrees below the shadow's frontier
+    are no taller than the equivalence automaton has states. That set is
+    non-empty and finite for every class, so its least element under the linear
+    order exists — and the exponential price is unavoidable: they also show a
+    structure where every automaton recognizing a complete system of
+    representatives has exponentially many states.
+
+    Until that is built, a caller who wants a quotient over trees names the
+    representatives instead: pick a formula ρ(x̄) true of exactly one element
+    per class and interpret with ``domain=δ ∧ ρ``, which is the same
+    construction with the choice made explicit.
     """
     if engine.well_order is None:
         raise NotImplementedError(
-            f"the {engine.name} engine has no well-order on encodings, so a "
-            f"quotient cannot pick class representatives; restrict the domain "
-            f"to a definable set of representatives instead (see the "
-            f"documentation of this construction)")
+            f"the {engine.name} engine does not build quotient representatives "
+            f"yet: they exist and are regular, but reaching them needs the "
+            f"shadow construction of Kuske & Weidner (MFCS 2011) rather than "
+            f"the least element of a class, since no tree-automatic order is "
+            f"well-founded. Restrict the domain to a definable set of "
+            f"representatives instead (see the documentation of this "
+            f"construction)")
     if _EQUIV in relations or _LE in relations:
         raise ValueError(f"{_EQUIV!r} and {_LE!r} are reserved for the "
                          f"quotient construction")

--- a/autstr/ordinals.py
+++ b/autstr/ordinals.py
@@ -1,13 +1,16 @@
-"""Ordinals below :math:`\\omega^\\omega`, as automatic structures.
+"""Ordinals as automatic structures, on both engines.
 
-Delhommé's theorem draws the line exactly here: the word-automatic ordinals are
-precisely those below :math:`\\omega^\\omega`. Every one of them lives in some
-:math:`\\omega^n`, so a factory for :math:`(\\omega^n, <)` covers all of them —
-and past that boundary the string engine cannot go. (:math:`\\omega^{\\omega}`
-itself and everything up to :math:`\\omega^{\\omega^\\omega}` needs the tree
-engine.)
+Delhommé's theorem draws two lines. The word-automatic ordinals are precisely
+those below :math:`\\omega^\\omega`, and the tree-automatic ones precisely those
+below :math:`\\omega^{\\omega^\\omega}`. Every ordinal below the first line
+lives in some :math:`\\omega^n` and every ordinal below the second in some
+:math:`\\omega^{\\omega^n}`, so two factories cover both classes exactly:
+`Ordinal` on the string engine and `TreeOrdinal` on the tree engine. Neither
+boundary ordinal is itself reachable — :math:`\\omega^\\omega` is not
+word-automatic, :math:`\\omega^{\\omega^\\omega}` not tree-automatic — which is
+why both take an exponent rather than being a single structure.
 
-The structure is *derived, not authored*. By Cantor normal form an ordinal
+`Ordinal` is *derived, not authored*. By Cantor normal form an ordinal
 :math:`\\alpha < \\omega^n` is uniquely :math:`\\sum_{i<n} \\omega^i c_i` with
 natural coefficients, so :math:`\\omega^n` is the set of n-tuples of naturals
 under reverse-lexicographic order — an n-dimensional first-order interpretation
@@ -28,15 +31,24 @@ ordinal of that value.
 The signature carries the strict order ``.lt``, equality ``.eq`` and the
 successor ``.succ``. Everything else is first-order over those and can be
 defined on the spot: a limit ordinal is one that is neither zero nor a
-successor, and ``Ordinal(n)`` has a definable least element but no greatest.
+successor, and both structures have a definable least element but no greatest.
+
+`TreeOrdinal` reaches past the word barrier by nesting the same idea: an
+ordinal below :math:`\\omega^{\\omega^n}` is a finite sequence of blocks
+indexed by the leading exponent coefficient, each block an ordinal below
+:math:`\\omega^{\\omega^{n-1}}`, bottoming out at a natural number. That nesting
+is a tree, and it is authored rather than interpreted — see `TreeOrdinal`.
 """
 from __future__ import annotations
 
-from typing import List, Sequence, Tuple, Union
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 from autstr.buildin.presentations import BuechiArithmetic
 from autstr.interpretations import interpret
+from autstr.sparse_tree_automata import SparseTreeAutomaton, Tree
 from autstr.symbolic import FunctionCodec, order_signature
+from autstr.tree_presentations import TreeAutomaticPresentation
+from autstr.utils.misc import encode_symbol
 
 #: base-2 encoding of a natural, least significant bit first — the convention
 #: of the Büchi arithmetic presentation over ℕ
@@ -181,3 +193,268 @@ class Ordinal:
 
     def __repr__(self):
         return f"<Ordinal omega^{self.n}>"
+
+
+#: a Python ordinal below omega^(omega^n): Cantor coefficients keyed by their
+#: exponent, itself an ordinal below omega^n written as a coefficient tuple
+CantorForm = Union[int, Mapping[Union[int, Sequence[int]], int]]
+
+
+class TreeOrdinal(TreeAutomaticPresentation):
+    """The ordinals below :math:`\\omega^{\\omega^n}`, under their natural
+    order — the tree-automatic ordinals, which reach exactly this far.
+
+    :param n: the exponent (n ≥ 1). ``TreeOrdinal(1)`` is
+        :math:`(\\omega^\\omega, <)`, the first ordinal past the word barrier.
+    :param max_states: optional cap on the subset determinizations inside
+        projection.
+
+    **The encoding.** By Cantor normal form an ordinal below
+    :math:`\\omega^{\\omega^n}` is a finite sum :math:`\\sum \\omega^{\\beta_i}
+    c_i` with exponents :math:`\\beta_i < \\omega^n` — and an exponent below
+    :math:`\\omega^n` is an n-tuple of naturals, exactly what `Ordinal` orders.
+    Splitting off the leading coefficient of the exponent turns that into a
+    recursion: an ordinal below :math:`\\omega^{\\omega^n}` is a sequence of
+    *blocks* indexed densely by that leading coefficient, each block an ordinal
+    below :math:`\\omega^{\\omega^{n-1}}`, and at n = 0 a natural number. So the
+    encoding is a left spine of blocks whose payloads hang right and are
+    themselves spines, bottoming out in binary chains — the shape the tree
+    engine reads natively.
+
+    Indexing the blocks *densely* by position is what makes the order easy:
+    two ordinals are aligned by construction, so the comparison is decided at
+    the deepest position where they differ, and a single three-state automaton
+    (``less``, ``equal``, ``greater``) computes it bottom-up at every level of
+    the nesting at once. Deeper is more significant everywhere — a deeper spine
+    node is a higher exponent, a deeper bit is a higher power of two — and a
+    position one ordinal has and the other lacks is a term the other is
+    missing, so present beats absent.
+
+    **Authored, not interpreted.** For n = 1 the trees coincide with Skolem
+    arithmetic's, since both encode a finitely supported map from
+    :math:`\\mathbb{N}` to :math:`\\mathbb{N}`. The order is *not* an
+    interpretation of it: permuting the primes is an automorphism of
+    :math:`(\\mathbb{N}_{>0}, \\cdot)`, so no ordering of the exponent
+    positions is definable there, while the encoding fixes one. The comparison
+    automaton is small enough that authoring it is the honest route.
+
+    Ordinals are written as maps from exponent to coefficient::
+
+        >>> W = TreeOrdinal(1)                    # ordinals below ω^ω
+        >>> a, b = W.symbolic().vars("a b")
+        >>> a.lt(b).evaluate().contains(a={2: 5}, b={3: 1})   # ω²·5 < ω³
+        True
+
+    An exponent is written as `Ordinal` writes one — an integer, or a tuple of
+    coefficients in descending order, left-padded to length n — and a plain
+    integer ordinal is the finite ordinal of that value.
+    """
+
+    #: spine node, tree root, the two bits, and padding
+    SPINE, ROOT, PAD = 's', 'o', '*'
+    LETTERS = frozenset({SPINE, ROOT, '0', '1', PAD})
+
+    #: the three verdicts the comparison automaton computes bottom-up
+    _EQUAL, _LESS, _GREATER = 0, 1, 2
+
+    #: y is the immediate successor of x -- first-order over the order, since
+    #: every ordinal has one, so it is defined rather than authored
+    _SUCCESSOR = 'Lt(x,y) & (not exists z.(Lt(x,z) & Lt(z,y)))'
+
+    def __init__(self, n: int = 1, max_states: Optional[int] = None) -> None:
+        if n < 1:
+            raise ValueError("the exponent must be >= 1")
+        self.n = n
+        super().__init__(
+            {'U': self._universe(n),
+             'Lt': self._comparison({self._LESS}),
+             'Eq': self._comparison({self._EQUAL})},
+            padding_symbol=self.PAD, max_states=max_states)
+        self._declare_deferred({'Succ': self._SUCCESSOR})
+
+    def default_signature(self):
+        """The strict order as ``.lt``, equality as ``.eq``, the successor as
+        ``.succ``, and ordinals written as Cantor maps."""
+        return order_signature(self.get_relation_symbols(), less='Lt',
+                               methods={'succ': 'Succ'},
+                               codec=FunctionCodec(self.encode, self.decode))
+
+    def is_total_order(self) -> bool:
+        """Whether ``Lt`` is a strict total order — decidable, being
+        first-order. Well-foundedness is not first-order, so it is not
+        checkable here; it holds by construction."""
+        return self.check(
+            'all x.(not Lt(x,x)) & '
+            'all x.(all y.(all z.((Lt(x,y) & Lt(y,z)) -> Lt(x,z)))) & '
+            'all x.(all y.(Lt(x,y) | Lt(y,x) | Eq(x,y)))')
+
+    def __repr__(self):
+        return f"<TreeOrdinal omega^(omega^{self.n})>"
+
+    # ---------------- encoding elements ----------------
+    def encode(self, value: CantorForm) -> Tree:
+        """The tree encoding an ordinal, written as a map from exponent to
+        coefficient (or as a plain integer, for a finite ordinal)."""
+        return Tree(self.ROOT, self._nest(self._normalize(value), self.n), None)
+
+    def decode(self, tree: Tree) -> Dict[Tuple[int, ...], int]:
+        """The ordinal a tree encodes, as a map from exponent tuple to
+        coefficient; the empty map is the ordinal zero."""
+        if tree is None or tree.label != self.ROOT or tree.right is not None:
+            raise ValueError("not an ordinal tree")
+        return self._unnest(tree.left, self.n)
+
+    def _normalize(self, value: CantorForm) -> Dict[Tuple[int, ...], int]:
+        """`value` as a map from full-length exponent tuples to non-zero
+        coefficients."""
+        if isinstance(value, int):
+            value = {(0,) * self.n: value}
+        normalized = {}
+        for exponent, coefficient in value.items():
+            if coefficient < 0:
+                raise ValueError(
+                    f"a Cantor coefficient must be a natural, got {coefficient}")
+            if not coefficient:
+                continue                       # a zero term is no term
+            normalized[self._exponent(exponent)] = coefficient
+        return normalized
+
+    def _exponent(self, exponent) -> Tuple[int, ...]:
+        """An exponent as a full n-tuple: an integer is the exponent of that
+        value, and a short tuple is left-padded, as in `Ordinal`."""
+        if isinstance(exponent, int):
+            exponent = (exponent,)
+        exponent = tuple(exponent)
+        if len(exponent) > self.n:
+            raise ValueError(
+                f"exponent {exponent} has {len(exponent)} coefficients, more "
+                f"than the {self.n} of an ordinal below omega^{self.n}")
+        if any(coefficient < 0 for coefficient in exponent):
+            raise ValueError(f"exponent {exponent} is not an ordinal")
+        return (0,) * (self.n - len(exponent)) + exponent
+
+    def _nest(self, terms: Dict[Tuple[int, ...], int], level: int):
+        """The blocks of `terms` as a spine, recursively; None is the zero
+        ordinal, which is no spine at all."""
+        if not terms:
+            return None
+        if not level:
+            return self._chain(terms[()])
+        blocks: Dict[int, Dict[Tuple[int, ...], int]] = {}
+        for exponent, coefficient in terms.items():
+            blocks.setdefault(exponent[0], {})[exponent[1:]] = coefficient
+        spine = None
+        for index in range(max(blocks), -1, -1):   # deepest block first
+            spine = Tree(self.SPINE, spine,
+                         self._nest(blocks.get(index, {}), level - 1))
+        return spine
+
+    def _unnest(self, node, level: int) -> Dict[Tuple[int, ...], int]:
+        if node is None:
+            return {}
+        if not level:
+            return {(): self._value(node)}
+        terms, index = {}, 0
+        while node is not None:
+            for exponent, coefficient in self._unnest(node.right,
+                                                      level - 1).items():
+                terms[(index,) + exponent] = coefficient
+            node, index = node.left, index + 1
+        return terms
+
+    @staticmethod
+    def _chain(coefficient: int):
+        """A positive natural as a binary chain, most significant bit deepest
+        — so that deeper is more significant here too."""
+        node = None
+        for bit in format(coefficient, 'b'):
+            node = Tree(bit, node, None)
+        return node
+
+    @staticmethod
+    def _value(node) -> int:
+        value, power = 0, 1
+        while node is not None:
+            value += power * int(node.label)
+            power, node = power * 2, node.left
+        return value
+
+    # ---------------- the automata ----------------
+    @classmethod
+    def _enc(cls, letters) -> int:
+        return encode_symbol(tuple(letters), cls.LETTERS)
+
+    @classmethod
+    def _universe(cls, n: int) -> SparseTreeAutomaton:
+        """One tree per ordinal: chains carry no leading zero, spines no
+        trailing zero block, and the nesting is exactly n deep."""
+        chain = 0
+        spine = {level: level for level in range(1, n + 1)}   # states 1..n
+        root, dead = n + 1, n + 2
+        bot = n + 3
+
+        exc = [(bot, bot, ('1',), chain),        # deepest bit is the MSB
+               (chain, bot, ('0',), chain),
+               (chain, bot, ('1',), chain)]
+        for level in range(1, n + 1):
+            payload = chain if level == 1 else spine[level - 1]
+            exc += [
+                # the deepest block of a spine must be non-zero, or the spine
+                # would encode an ordinal it is already too long for
+                (bot, payload, (cls.SPINE,), spine[level]),
+                (spine[level], payload, (cls.SPINE,), spine[level]),
+                (spine[level], bot, (cls.SPINE,), spine[level]),
+            ]
+        exc += [(bot, bot, (cls.ROOT,), root),           # the ordinal zero
+                (spine[n], bot, (cls.ROOT,), root)]
+
+        accepting = [False] * (n + 3)
+        accepting[root] = True
+        return SparseTreeAutomaton(
+            n + 3, dead,
+            [e[0] for e in exc], [e[1] for e in exc],
+            [cls._enc(e[2]) for e in exc], [e[3] for e in exc],
+            accepting, 1, set(cls.LETTERS))
+
+    @classmethod
+    def _comparison(cls, accepting) -> SparseTreeAutomaton:
+        """The order, decided at the deepest position where two ordinals
+        differ.
+
+        Every node combines its children the same way, whatever level of the
+        nesting it sits at: a verdict from the left subtree stands, since left
+        is deeper and deeper is more significant; failing that the right
+        subtree, which is this block's payload; failing that the labels
+        themselves, where a present position beats an absent one.
+        """
+        equal, less, greater = cls._EQUAL, cls._LESS, cls._GREATER
+        bot = 3
+
+        def verdict(one: str, other: str) -> int:
+            if one == other:
+                return equal
+            if one == cls.PAD:                 # a term the other ordinal has
+                return less
+            if other == cls.PAD:
+                return greater
+            return less if one < other else greater      # '0' before '1'
+
+        # both subtrees agree so far: the labels here decide
+        exc = [(left, right, (one, other), verdict(one, other))
+               for left in (bot, equal) for right in (bot, equal)
+               for one in sorted(cls.LETTERS) for other in sorted(cls.LETTERS)
+               if verdict(one, other) != equal]
+
+        # a subtree that has already decided outranks everything above it
+        defaults = [(left, right, left if left in (less, greater) else right)
+                    for left in (bot, equal, less, greater)
+                    for right in (bot, equal, less, greater)
+                    if left in (less, greater) or right in (less, greater)]
+
+        return SparseTreeAutomaton(
+            3, equal,
+            [e[0] for e in exc], [e[1] for e in exc],
+            [cls._enc(e[2]) for e in exc], [e[3] for e in exc],
+            [state in accepting for state in range(3)], 2, set(cls.LETTERS),
+            pd_left=[d[0] for d in defaults], pd_right=[d[1] for d in defaults],
+            pd_target=[d[2] for d in defaults])

--- a/autstr/tree_presentations.py
+++ b/autstr/tree_presentations.py
@@ -171,6 +171,31 @@ class TreeAutomaticPresentation(DeferredRelations):
             # leave the temporary relations installed on the presentation.
             self.automata = backup
 
+    def _operand_automaton(self, psi, free_operand, free_vars
+                           ) -> SparseTreeAutomaton:
+        """A connective's operand, placed into the enclosing formula's tape
+        order.
+
+        A sentence has no tapes to place: it collapses to the all/none marker,
+        whose single tape is a placeholder rather than a variable, so renaming
+        it into the enclosing arity is meaningless (and, when the enclosing
+        formula is itself a sentence, impossible — there is no tape to rename
+        to). It is remade at the enclosing arity instead: false becomes the
+        empty relation, true the full one, which over a structure is the
+        product of domains rather than every tree.
+        """
+        sta = self._build_automaton(psi)
+        arity = max(len(free_vars), 1)
+        if free_operand:
+            return expand(sta, arity, [free_vars.index(v)
+                                       for v in free_operand])
+        if sta.is_empty():
+            return tree_zero(arity, self.base_alphabet)
+        # a true sentence: the marker convention at arity 1, so that an
+        # enclosing sentence stays a marker; the domain otherwise
+        return tree_one(1, self.base_alphabet) if not free_vars \
+            else self._domain_product(arity)
+
     def _build_automaton(self, phi) -> SparseTreeAutomaton:
         if isinstance(phi, str):
             phi = logic.Expression.fromstring(phi)
@@ -214,10 +239,8 @@ class TreeAutomaticPresentation(DeferredRelations):
             free_vars = get_free_elementary_vars(phi)
             free_l = get_free_elementary_vars(phi.first)
             free_r = get_free_elementary_vars(phi.second)
-            left = expand(self._build_automaton(phi.first), len(free_vars),
-                          [free_vars.index(v) for v in free_l])
-            right = expand(self._build_automaton(phi.second), len(free_vars),
-                           [free_vars.index(v) for v in free_r])
+            left = self._operand_automaton(phi.first, free_l, free_vars)
+            right = self._operand_automaton(phi.second, free_r, free_vars)
             if isinstance(phi, logic.AndExpression):
                 return minimize(left.intersection(right))
             return minimize(left.union(right))

--- a/autstr/utils/tree_automata_tools.py
+++ b/autstr/utils/tree_automata_tools.py
@@ -127,6 +127,40 @@ def permute_tapes(sta: SparseTreeAutomaton, perm: List[int]
         pair_keys=sta.pair_keys, pair_nodes=np.array(nodes, dtype=np.int64))
 
 
+def fold_tapes(sta: SparseTreeAutomaton, k: int) -> SparseTreeAutomaton:
+    """Group every `k` consecutive tapes of a convolution into one tape over
+    the product alphabet Sigma^k.
+
+    An automaton reading ``k * r`` tapes over Sigma becomes one reading ``r``
+    tapes whose letters are k-tuples — the fold that turns the many-tape output
+    of a k-dimensional interpretation into a structure whose elements are
+    k-tuples of trees. Since the convolution of k trees is one tree over
+    k-tuples, an element of the interpreted structure *is* such a tree, and
+    nothing about the shapes changes: the fold only regroups the alphabet.
+
+    The regrouping is the same diagram surgery as in the string engine — the
+    symbol diagrams are ordinary MTBDDs either way, so `NodeStore.fold_tapes`
+    does the work here too, applied to each child pair's diagram. No state is
+    added, and lexicographic tuple order matches `encode_symbol`, so encodings
+    line up.
+    """
+    import itertools
+    if sta.symbol_arity % k:
+        raise ValueError(
+            f"arity {sta.symbol_arity} is not a multiple of k={k}")
+    if k == 1:
+        return sta
+    store = sta.store
+    product_alphabet = set(
+        itertools.product(sorted(sta.base_alphabet_frozen), repeat=k))
+    nodes = [store.fold_tapes(int(node), sta.symbol_arity, sta.m, sta.bits, k)
+             for node in sta.pair_nodes.tolist()]
+    return SparseTreeAutomaton(
+        sta.num_states, sta.default_state, is_accepting=sta.is_accepting,
+        symbol_arity=sta.symbol_arity // k, base_alphabet=product_alphabet,
+        pair_keys=sta.pair_keys, pair_nodes=np.array(nodes, dtype=np.int64))
+
+
 # ====================================================================
 # Existential projection
 # ====================================================================

--- a/tests/test_ordinals.py
+++ b/tests/test_ordinals.py
@@ -135,3 +135,214 @@ class TestConstruction:
         from autstr.buildin.presentations import BuechiArithmetic
         assert omega.presentation.automata['Lt'].num_states == \
             BuechiArithmetic().automata['Lt'].num_states
+
+
+# ======================================================================
+# TreeOrdinal: the ordinals below omega^(omega^n), on the tree engine
+# ======================================================================
+
+from autstr.ordinals import TreeOrdinal                        # noqa: E402
+from autstr.sparse_tree_automata import Tree                   # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def omega_to_the_omega():
+    return TreeOrdinal(1)
+
+
+@pytest.fixture(scope="module")
+def big():
+    return TreeOrdinal(2)
+
+
+def ordinal_key(structure, cantor):
+    """The oracle: a Cantor map as the list of its terms in descending
+    exponent order. Python compares those lists exactly as the ordinals they
+    denote compare -- a larger leading exponent wins, then a larger leading
+    coefficient, and a longer list wins over a prefix of itself since every
+    further term is positive."""
+    return sorted(structure._normalize(cantor).items(), reverse=True)
+
+
+#: ordinals below omega^omega, written as Cantor maps
+SMALL_SPACE = [0, 1, 2, 5, {1: 1}, {1: 2}, {1: 1, 0: 1}, {2: 1}, {2: 5},
+               {2: 1, 1: 3, 0: 7}, {4: 1}, {4: 1, 0: 1}, {3: 2, 1: 1}]
+
+#: ordinals below omega^(omega^2); an exponent is now a pair
+BIG_SPACE = [0, 1, 7, {(0, 1): 1}, {(0, 2): 3}, {(1, 0): 1}, {(1, 0): 2},
+             {(1, 0): 1, (0, 5): 4}, {(2, 0): 1}, {(1, 3): 1},
+             {(1, 3): 1, (0, 0): 9}, {3: 2}]
+
+
+class TestTreeCodec:
+    def test_roundtrip(self, omega_to_the_omega):
+        W = omega_to_the_omega
+        for value in SMALL_SPACE:
+            assert W.decode(W.encode(value)) == W._normalize(value)
+
+    def test_zero_is_the_empty_map(self, omega_to_the_omega):
+        W = omega_to_the_omega
+        assert W.decode(W.encode(0)) == {}
+        assert W.encode(0) == Tree('o')
+
+    def test_an_integer_is_the_finite_ordinal(self, omega_to_the_omega):
+        W = omega_to_the_omega
+        assert W.encode(5) == W.encode({0: 5})
+
+    def test_an_exponent_may_be_an_integer_or_a_short_tuple(self, big):
+        assert big.encode({3: 2}) == big.encode({(0, 3): 2})
+        assert big.decode(big.encode({3: 2})) == {(0, 3): 2}
+
+    def test_a_zero_coefficient_is_no_term(self, omega_to_the_omega):
+        W = omega_to_the_omega
+        assert W.encode({2: 1, 5: 0}) == W.encode({2: 1})
+
+    def test_a_negative_coefficient_is_rejected(self, omega_to_the_omega):
+        with pytest.raises(ValueError, match="natural"):
+            omega_to_the_omega.encode({1: -2})
+
+    def test_too_long_an_exponent_is_rejected(self, omega_to_the_omega):
+        with pytest.raises(ValueError, match="more than"):
+            omega_to_the_omega.encode({(1, 2): 1})
+
+
+class TestTreeUniverse:
+    """One tree per ordinal: the universe automaton rejects every other tree,
+    which is what makes the encoding a bijection and the order automaton's
+    position-wise alignment sound."""
+
+    def test_accepts_the_canonical_trees(self, omega_to_the_omega):
+        W = omega_to_the_omega
+        for value in SMALL_SPACE:
+            assert W.automata['U'].accepts(W.encode(value)), value
+
+    def test_rejects_a_trailing_zero_block(self, omega_to_the_omega):
+        # a spine node with no payload is a zero block; as the deepest node it
+        # would give the ordinal zero a second encoding
+        assert not omega_to_the_omega.automata['U'].accepts(
+            Tree('o', Tree('s', None, None), None))
+
+    def test_rejects_a_leading_zero_bit(self, omega_to_the_omega):
+        # the chain '01' is the coefficient 1 written with a leading zero:
+        # the deepest bit is the most significant and must be a one
+        chain = Tree('1', Tree('0', None, None), None)
+        assert not omega_to_the_omega.automata['U'].accepts(
+            Tree('o', Tree('s', None, chain), None))
+
+    def test_rejects_the_wrong_nesting_depth(self, big):
+        # at n = 2 a block is itself a spine, never a bare coefficient chain
+        flat = Tree('o', Tree('s', None, Tree('1', None, None)), None)
+        assert not big.automata['U'].accepts(flat)
+        assert big.automata['U'].accepts(big.encode({(0, 0): 1}))
+
+
+class TestTreeOrder:
+    @pytest.mark.parametrize("structure_name,space",
+                             [('omega_to_the_omega', SMALL_SPACE),
+                              ('big', BIG_SPACE)])
+    def test_agrees_with_the_cantor_oracle(self, structure_name, space,
+                                           request):
+        structure = request.getfixturevalue(structure_name)
+        less, equal = structure.automata['Lt'], structure.automata['Eq']
+        for a, b in itertools.product(space, repeat=2):
+            x, y = structure.encode(a), structure.encode(b)
+            key_a, key_b = (ordinal_key(structure, a),
+                            ordinal_key(structure, b))
+            assert less.accepts(x, y) == (key_a < key_b), (a, b)
+            assert equal.accepts(x, y) == (key_a == key_b), (a, b)
+
+    def test_is_a_strict_total_order(self, omega_to_the_omega, big):
+        assert omega_to_the_omega.is_total_order()
+        assert big.is_total_order()
+
+    def test_the_symbolic_surface(self, omega_to_the_omega):
+        a, b = omega_to_the_omega.symbolic().vars('a b')
+        assert a.lt(b).evaluate().contains(a={2: 5}, b={3: 1})   # ω²·5 < ω³
+        assert not a.lt(b).evaluate().contains(a={3: 1}, b={2: 5})
+
+    def test_agrees_with_the_word_engine_where_they_overlap(
+            self, omega_to_the_omega):
+        """Two independent constructions of the same order: ω² sits inside
+        ω^ω, and `Ordinal(2)` builds it by interpreting Büchi arithmetic while
+        `TreeOrdinal(1)` builds it from hand-written tree automata."""
+        word = Ordinal(2)
+        x, y = word.symbolic().vars('x y')
+        word_less = x.lt(y).evaluate()
+        tree_less = omega_to_the_omega.automata['Lt']
+
+        window = list(itertools.product(range(3), range(3)))
+        for (a1, a0), (b1, b0) in itertools.product(window, repeat=2):
+            tree = tree_less.accepts(
+                omega_to_the_omega.encode({1: a1, 0: a0}),
+                omega_to_the_omega.encode({1: b1, 0: b0}))
+            assert word_less.contains(x=(a1, a0), y=(b1, b0)) == tree
+
+
+class TestTreeSuccessor:
+    """`Succ` is defined from the order rather than authored -- every ordinal
+    has an immediate successor, so `y = x + 1` is first-order."""
+
+    def test_semantics(self, omega_to_the_omega):
+        # deferred: it is built the first time a query mentions it
+        x, y = omega_to_the_omega.symbolic().vars('x y')
+        successor = x.succ(y).evaluate()
+        for a, b, want in [(3, 4, True), (3, 5, False),
+                           ({1: 1}, {1: 1, 0: 1}, True),
+                           ({1: 1, 0: 2}, {1: 1, 0: 3}, True),
+                           (7, {1: 1}, False)]:        # ω is a limit
+            assert successor.contains(x=a, y=b) == want, (a, b)
+
+    def test_every_ordinal_has_one(self, omega_to_the_omega):
+        assert omega_to_the_omega.check('all x.(exists y.(Succ(x,y)))')
+
+    def test_the_order_is_discrete_upwards(self, omega_to_the_omega):
+        assert omega_to_the_omega.check(
+            'all x.(all y.(Succ(x,y) -> (not exists z.(Lt(x,z) & Lt(z,y)))))')
+
+
+def _zero(v):
+    return f'all q.(Lt({v},q) | Eq({v},q))'
+
+
+def _limit(v):
+    return f'((not ({_zero(v)})) & (not exists p.(Succ(p,{v}))))'
+
+
+def _limit_of_limits(v):
+    return (f'({_limit(v)} & all w.(Lt(w,{v}) -> exists u.('
+            f'Lt(w,u) & Lt(u,{v}) & {_limit("u")})))')
+
+
+class TestPastTheWordBarrier:
+    """What the tree engine buys. In ω^n the limit ordinals stack only n-1
+    deep -- the limits of ω² are the ω·k, and no ω·k is a limit of those. In
+    ω^ω they stack arbitrarily, and ω² itself is a limit of limits. So one
+    first-order sentence separates the two structures, and only the tree
+    engine can decide it on ω^ω.
+    """
+
+    def test_both_have_limit_ordinals(self, omega_to_the_omega):
+        assert omega_to_the_omega.check(f'exists x.({_limit("x")})')
+        assert Ordinal(2).check(f'exists x.({_limit("x")})')
+
+    def test_only_omega_to_the_omega_has_a_limit_of_limits(
+            self, omega_to_the_omega):
+        assert omega_to_the_omega.check(f'exists x.({_limit_of_limits("x")})')
+        assert not Ordinal(2).check(f'exists x.({_limit_of_limits("x")})')
+
+    def test_it_has_a_least_element_and_no_greatest(self, omega_to_the_omega):
+        assert omega_to_the_omega.check('exists x.(all y.(Lt(x,y) | Eq(x,y)))')
+        assert omega_to_the_omega.check('all x.(exists y.(Lt(x,y)))')
+
+
+class TestTreeConstruction:
+    def test_exponent_must_be_positive(self):
+        with pytest.raises(ValueError, match=">= 1"):
+            TreeOrdinal(0)
+
+    def test_repr(self, omega_to_the_omega):
+        assert repr(omega_to_the_omega) == "<TreeOrdinal omega^(omega^1)>"
+
+    def test_the_relations(self, omega_to_the_omega):
+        assert sorted(omega_to_the_omega.get_relation_symbols()) == \
+            ['Eq', 'Lt', 'Succ', 'U']

--- a/tests/test_tree_interpretations.py
+++ b/tests/test_tree_interpretations.py
@@ -1,0 +1,181 @@
+"""First-order interpretations over the tree engine.
+
+The source is Skolem arithmetic, (N_{>0}, ·) — multiplication is not
+string-automatic, so these interpretations exist only over trees. Python's own
+arithmetic is the oracle throughout.
+
+An element of a k-dimensional interpretation is a k-tuple of trees, which *is*
+one tree over k-tuples, since a tree convolution already overlays the shapes.
+So the fold that regroups the tapes is the same operation as in the string
+engine, and these tests check that the structure it produces means what it
+should.
+"""
+import itertools
+
+import pytest
+
+from autstr.buildin.tree_presentations import SkolemArithmetic
+from autstr.interpretations import interpret
+from autstr.sparse_tree_automata import Tree, convolve_trees
+from autstr.tree_presentations import TreeAutomaticPresentation
+
+PAD = SkolemArithmetic.PAD
+LETTERS = SkolemArithmetic.LETTERS
+
+
+@pytest.fixture(scope="module")
+def skolem():
+    return SkolemArithmetic()
+
+
+def tuple_tree(*numbers):
+    """A k-tuple of naturals as one tree over k-tuples — an element of a
+    k-dimensional interpretation of Skolem arithmetic."""
+    return convolve_trees([SkolemArithmetic.encode(n) for n in numbers],
+                          LETTERS, PAD)
+
+
+def as_one_tape(tree):
+    """An element tree wrapped for a *unary* relation, whose single tape reads
+    whole elements."""
+    if tree is None:
+        return None
+    return Tree((tree.label,), as_one_tape(tree.left), as_one_tape(tree.right))
+
+
+class TestOneDimensional:
+    """A definable reduct with a restricted domain: elements keep the source's
+    trees, so the oracle is plain arithmetic on the numbers they encode."""
+
+    @pytest.fixture(scope="class")
+    def squares(self, skolem):
+        return interpret(skolem, domain=('exists r.(M(r,r,x))', ['x']),
+                         relations={'M': ('M(x,y,z)', ['x', 'y', 'z'])})
+
+    def test_the_result_is_a_tree_presentation(self, squares):
+        assert isinstance(squares, TreeAutomaticPresentation)
+        assert sorted(squares.get_relation_symbols()) == ['M', 'U']
+
+    def test_the_domain_is_the_squares(self, squares):
+        universe = squares.automata['U']
+        for n in range(1, 30):
+            is_square = round(n ** 0.5) ** 2 == n
+            assert universe.accepts(SkolemArithmetic.encode(n)) == is_square, n
+
+    def test_multiplication_restricted_to_the_domain(self, squares):
+        product = squares.automata['M']
+        squares_only = [1, 4, 9, 16, 25, 36, 100]
+        for a, b in itertools.product(squares_only, repeat=2):
+            for c in squares_only:
+                want = a * b == c
+                assert product.accepts(*map(SkolemArithmetic.encode,
+                                            (a, b, c))) == want, (a, b, c)
+        # a product of the source whose factors leave the domain is gone,
+        # even though it holds in the source: 2 · 2 = 4 and 2 is no square
+        assert product.accepts(*map(SkolemArithmetic.encode, (4, 9, 36)))
+        assert not product.accepts(*map(SkolemArithmetic.encode, (2, 2, 4)))
+
+    def test_a_first_order_fact_about_the_squares(self, squares):
+        # the squares are closed under multiplication, and every square is a
+        # product of two squares (itself and 1)
+        assert squares.check('all x.(all y.(exists z.(M(x,y,z))))')
+        assert squares.check('all x.(exists y.(exists z.(M(y,z,x))))')
+
+
+class TestTwoDimensional:
+    """Elements are pairs of naturals under componentwise multiplication."""
+
+    @pytest.fixture(scope="class")
+    def pairs(self, skolem):
+        return interpret(
+            skolem,
+            domain=('Eq(x0,x0) & Eq(x1,x1)', ['x0', 'x1']),
+            relations={'M': ('M(x0,y0,z0) & M(x1,y1,z1)',
+                             ['x0', 'x1', 'y0', 'y1', 'z0', 'z1'])},
+            dimension=2)
+
+    def test_the_alphabet_is_the_square_of_the_sources(self, pairs, skolem):
+        assert len(pairs.base_alphabet) == len(skolem.base_alphabet) ** 2
+        assert pairs.padding_symbol == (PAD, PAD)
+        assert pairs.automata['U'].symbol_arity == 1
+        assert pairs.automata['M'].symbol_arity == 3
+
+    def test_the_universe_is_every_pair(self, pairs):
+        universe = pairs.automata['U']
+        for a, b in itertools.product([1, 2, 6, 10, 27], repeat=2):
+            assert universe.accepts(as_one_tape(tuple_tree(a, b))), (a, b)
+
+    def test_multiplication_is_componentwise(self, pairs):
+        product = pairs.automata['M']
+        space = [(1, 1), (2, 3), (5, 7), (10, 21), (4, 9), (2, 2)]
+        for x, y in itertools.product(space, repeat=2):
+            for z in space:
+                want = (x[0] * y[0], x[1] * y[1]) == z
+                assert product.accepts(tuple_tree(*x), tuple_tree(*y),
+                                       tuple_tree(*z)) == want, (x, y, z)
+
+    def test_first_order_facts_about_the_product_monoid(self, pairs):
+        assert pairs.check('exists u.(all x.(M(u,x,x)))')          # identity
+        assert pairs.check('all x.(all y.(exists z.(M(x,y,z))))')  # total
+        assert pairs.check(                                        # commutes
+            'all x.(all y.(all z.(M(x,y,z) -> M(y,x,z))))')
+
+    def test_a_sparse_domain_does_not_blow_up(self, skolem):
+        """The diagonal {(a, a)} realizes only a sparse subset of the pairs,
+        yet minimization keeps multiplication the size of the one-dimensional
+        encoding — the tree counterpart of the same measurement on words."""
+        diagonal = interpret(
+            skolem, domain=('Eq(x0,x1)', ['x0', 'x1']),
+            relations={'M': ('Eq(x0,x1) & Eq(y0,y1) & Eq(z0,z1) & M(x0,y0,z0)',
+                             ['x0', 'x1', 'y0', 'y1', 'z0', 'z1'])},
+            dimension=2)
+        native = interpret(skolem, domain=('Eq(x,x)', ['x']),
+                           relations={'M': ('M(x,y,z)', ['x', 'y', 'z'])})
+        assert diagonal.automata['M'].num_states == \
+            native.automata['M'].num_states == \
+            skolem.automata['M'].num_states
+
+
+class TestQuotientsAreNotAvailableOverTrees:
+    """Choosing class representatives needs a well-order on encodings.
+    Shortlex works over words because the convolution aligns positions, which
+    makes comparing lengths free; a tree convolution aligns shapes instead, and
+    a bottom-up automaton cannot compare two trees' sizes at all. So the
+    construction refuses rather than quietly picking a non-representative.
+    """
+
+    def test_the_quotient_is_refused_with_an_explanation(self, skolem):
+        with pytest.raises(NotImplementedError, match="well-order"):
+            interpret(skolem, domain=('Eq(x,x)', ['x']),
+                      relations={'M': ('M(x,y,z)', ['x', 'y', 'z'])},
+                      quotient=('Eq(x,y)', ['x', 'y']))
+
+    def test_naming_the_representatives_is_the_way_round_it(self, skolem):
+        """The same construction with the choice made explicit: restrict the
+        domain to one element per class. Here the classes are "same square",
+        and the representative is the square itself."""
+        representatives = interpret(
+            skolem, domain=('exists r.(M(r,r,x))', ['x']),
+            relations={'M': ('M(x,y,z)', ['x', 'y', 'z'])})
+        assert representatives.automata['U'].accepts(
+            SkolemArithmetic.encode(9))
+        assert not representatives.automata['U'].accepts(
+            SkolemArithmetic.encode(3))
+
+
+class TestValidationCarriesOverToTrees:
+    def test_domain_needs_one_element(self, skolem):
+        with pytest.raises(ValueError, match="defines 2 element"):
+            interpret(skolem, domain=('M(x,y,y)', ['x', 'y']), relations={})
+
+    def test_free_variables_must_be_a_multiple_of_the_dimension(self, skolem):
+        with pytest.raises(ValueError, match="multiple of the dimension"):
+            interpret(skolem,
+                      domain=('Eq(x0,x0) & Eq(x1,x1)', ['x0', 'x1']),
+                      relations={'R': ('M(x0,x1,x2)', ['x0', 'x1', 'x2'])},
+                      dimension=2)
+
+    def test_universe_symbol_is_reserved(self, skolem):
+        with pytest.raises(ValueError, match="reserved universe"):
+            interpret(skolem, domain=('Eq(x,x)', ['x']),
+                      relations={'U': ('Eq(x,y)', ['x', 'y'])})

--- a/tests/test_tree_interpretations.py
+++ b/tests/test_tree_interpretations.py
@@ -136,16 +136,17 @@ class TestTwoDimensional:
             skolem.automata['M'].num_states
 
 
-class TestQuotientsAreNotAvailableOverTrees:
-    """Choosing class representatives needs a well-order on encodings.
-    Shortlex works over words because the convolution aligns positions, which
-    makes comparing lengths free; a tree convolution aligns shapes instead, and
-    a bottom-up automaton cannot compare two trees' sizes at all. So the
-    construction refuses rather than quietly picking a non-representative.
+class TestQuotientsAreNotBuiltForTreesYet:
+    """Representatives exist — every tree-automatic equivalence has a regular
+    complete system of them — but not by the string engine's route of taking
+    the least element of a class, since no tree-automatic order is
+    well-founded. Reaching them needs the shadow construction of Kuske &
+    Weidner (MFCS 2011), which is not built here, so the construction refuses
+    rather than quietly picking a non-representative.
     """
 
     def test_the_quotient_is_refused_with_an_explanation(self, skolem):
-        with pytest.raises(NotImplementedError, match="well-order"):
+        with pytest.raises(NotImplementedError, match="well-founded"):
             interpret(skolem, domain=('Eq(x,x)', ['x']),
                       relations={'M': ('M(x,y,z)', ['x', 'y', 'z'])},
                       quotient=('Eq(x,y)', ['x', 'y']))

--- a/tests/test_tree_presentations.py
+++ b/tests/test_tree_presentations.py
@@ -7,7 +7,9 @@ from autstr.buildin.presentations import BuechiArithmeticZ
 from autstr.sparse_automata import SparseDFA
 from autstr.sparse_tree_automata import Tree
 from autstr.tree_presentations import TreeAutomaticPresentation
-from autstr.utils.tree_automata_tools import from_string_dfa, string_chain
+from autstr.utils.tree_automata_tools import (
+    equivalent, from_string_dfa, minimize, string_chain,
+)
 from test_tree_automata import random_sta  # noqa: F401 (import path check)
 
 
@@ -139,3 +141,45 @@ class TestBuechiCrossValidation:
             t_got = t_rel.accepts(string_chain(word))
             assert s_got == want, (x, y, z)
             assert t_got == want, (x, y, z)
+
+
+class TestSentencesUnderConnectives:
+    """A sentence has no free variables, so it evaluates to the all/none
+    marker: an arity-1 automaton, non-empty exactly when the sentence is true.
+    Placing it into an enclosing formula is therefore not a tape renaming --
+    attempting one raised IndexError, and for two sentences there was no tape
+    to rename to at all. The tree engine had the same gap as the string one,
+    and answers the same way.
+    """
+
+    CONNECTIVES = {'&': lambda a, b: a and b,
+                   '|': lambda a, b: a or b,
+                   '->': lambda a, b: (not a) or b,
+                   '<->': lambda a, b: a == b}
+
+    @pytest.mark.parametrize("connective", list(CONNECTIVES))
+    @pytest.mark.parametrize("left,right", [(True, True), (True, False),
+                                            (False, True), (False, False)])
+    def test_two_sentences(self, engines, connective, left, right):
+        _, trees = engines
+        true, false = 'all x.(exists y.(Lt(x,y)))', 'exists x.(all y.(Lt(x,y)))'
+        phi = (f'({true if left else false}) {connective} '
+               f'({true if right else false})')
+        assert trees.check(phi) == self.CONNECTIVES[connective](left, right)
+
+    def test_a_sentence_beside_an_open_formula(self, engines):
+        _, trees = engines
+        true, false = 'all x.(exists y.(Lt(x,y)))', 'exists x.(all y.(Lt(x,y)))'
+        assert trees.check(f'({true}) & Lt(y,z)')
+        assert not trees.check(f'({false}) & Lt(y,z)')
+        assert trees.check(f'({false}) | Lt(y,z)')
+
+    def test_a_true_operand_is_the_domain_not_every_tree(self, engines):
+        """A subformula's automaton is a relation over the domain. The marker
+        is not -- it accepts every tree -- so a true sentence beside an open
+        formula must contribute the product of domains instead."""
+        _, trees = engines
+        true = 'all x.(exists y.(Lt(x,y)))'
+        filled = trees.evaluate(f'({true}) | Lt(y,z)')
+        assert equivalent(minimize(filled),
+                          minimize(trees._domain_product(2)))

--- a/tests/test_tree_presentations.py
+++ b/tests/test_tree_presentations.py
@@ -174,6 +174,17 @@ class TestSentencesUnderConnectives:
         assert not trees.check(f'({false}) & Lt(y,z)')
         assert trees.check(f'({false}) | Lt(y,z)')
 
+    def test_the_two_engines_agree(self, engines):
+        """Both engines answer a sentence with a marker and place it into a
+        connective the same way, so the same formula must come out the same on
+        the same structure."""
+        strings, trees = engines
+        true, false = 'all x.(exists y.(Lt(x,y)))', 'exists x.(all y.(Lt(x,y)))'
+        for phi in [f'({true}) & ({false})', f'({true}) | ({false})',
+                    f'({false}) -> ({true})', f'({true}) <-> ({true})',
+                    f'({false}) <-> ({true})', f'not (({true}) & ({false}))']:
+            assert strings.check(phi) == trees.check(phi), phi
+
     def test_a_true_operand_is_the_domain_not_every_tree(self, engines):
         """A subformula's automaton is a relation over the domain. The marker
         is not -- it accepts every tree -- so a true sentence beside an open

--- a/tests/test_tree_tools.py
+++ b/tests/test_tree_tools.py
@@ -7,7 +7,7 @@ from autstr.utils.tree_automata_tools import k_deeper_automaton
 from autstr.sparse_tree_automata import SparseTreeAutomaton, Tree, tree_to_arrays
 from autstr.utils.misc import encode_symbol
 from autstr.utils.tree_automata_tools import (
-    attach_padding, equivalent, expand, minimize, project,
+    attach_padding, equivalent, expand, fold_tapes, minimize, project,
 )
 from test_tree_automata import RefDTA, random_sta, random_tree
 
@@ -393,3 +393,44 @@ class TestKDeeperAutomaton:
                       Tree(('*', 'a'), Tree(('*', 'a'))))
         assert self._automaton(k=2).accepts(forked)
         assert not self._automaton(k=3).accepts(forked)
+
+
+# ====================================================================
+# fold_tapes
+# ====================================================================
+
+class TestFoldTapes:
+    """Grouping every k tapes into one product-alphabet tape must preserve the
+    accepted language. The grouping is contiguous and mixed-radix, so a
+    symbol's integer code is unchanged by the fold and the folded automaton run
+    on the same codes must agree with the original — a real test when m is not
+    a power of two, since the diagram is then genuinely rebuilt over a
+    different number of bits."""
+
+    def test_preserves_the_language(self):
+        rng = random.Random(2026)
+        for trial in range(25):
+            m = rng.randint(2, 3)                 # 3 is not a power of two
+            k = rng.randint(2, 3)
+            r = rng.randint(1, 2)
+            source = random_sta_arity(rng, k * r, m)
+            folded = fold_tapes(source, k)
+            assert folded.symbol_arity == r
+            assert len(folded.base_alphabet) == m ** k
+            for _ in range(20):
+                tree = random_tree(rng, m ** (k * r))
+                arrays = tree_to_arrays_encoded(tree)
+                got = bool(folded.is_accepting[folded.run(*arrays)])
+                want = bool(source.is_accepting[source.run(*arrays)])
+                assert got == want, trial
+
+    def test_k_one_is_the_automaton_itself(self):
+        rng = random.Random(7)
+        source = random_sta_arity(rng, 2, 3)
+        assert fold_tapes(source, 1) is source
+
+    def test_arity_must_be_divisible(self):
+        rng = random.Random(8)
+        source = random_sta_arity(rng, 3, 2)
+        with pytest.raises(ValueError, match="multiple"):
+            fold_tapes(source, 2)


### PR DESCRIPTION
Tier II opens: first-order interpretations now work over the tree engine, and
the first structure built past the word barrier — the tree-automatic ordinals.

## Interpretations over trees

`interpret` takes an `AutomaticPresentation` or a `TreeAutomaticPresentation`
and returns a presentation of the same kind. The orchestration was already
engine-agnostic — evaluate the formulas, order the tapes, fold every k into one
element tape — so the dispatch is a small record of the three operations that
differ.

The fold turned out to be nearly free. Both engines encode a convolution letter
the same way, an MTBDD over its binary digits, tape-major, so the existing
`NodeStore.fold_tapes` primitive works unchanged on tree automata, applied per
child pair. And the meaning needs no argument over trees: the convolution of k
trees already *is* one tree over k-tuples, so folding regroups the alphabet and
leaves the shapes alone.

Skolem arithmetic is the test source, and deliberately: multiplication is not
string-automatic, so these interpretations exist only over trees. Dimension 1
(the squares, with multiplication restricted to them) and dimension 2 (pairs
under componentwise multiplication) are both checked pointwise against Python
arithmetic. The sparse-domain measurement carries over from the string engine
intact — the two-dimensional diagonal gives multiplication the same 13 states as
the one-dimensional encoding.

## Ordinals below ω^(ω^n)

Delhommé's two boundaries now both have a factory: `Ordinal(n)` covers the
word-automatic ordinals, those below ω^ω, and `TreeOrdinal(n)` the
tree-automatic ones, those below ω^(ω^ω).

The encoding nests the Cantor normal form. An ordinal below ω^(ω^n) is a sum of
terms whose exponents lie below ω^n, and such an exponent is an n-tuple of
naturals; splitting off its leading coefficient turns that into a recursion — a
sequence of blocks indexed densely by that coefficient, each block an ordinal
below ω^(ω^(n-1)), bottoming out at a natural number.

Indexing blocks *densely by position* is what makes the order cheap. Two
ordinals align by construction, so the comparison is settled at the deepest
position where they differ, and a single three-state automaton computes it
bottom-up across every level of the nesting at once: a verdict from the left
subtree stands, since deeper is more significant everywhere — a deeper spine
node is a higher exponent, a deeper bit a higher power of two — then the right
subtree, then the labels, where a position one ordinal has and the other lacks
is a term the other is missing. `U` is 6 states and `Lt` is 16.

Authored rather than interpreted, and checked rather than assumed: for n = 1 the
trees coincide with Skolem arithmetic's, since both encode a finitely supported
map from ℕ to ℕ, but permuting the primes is an automorphism of (ℕ, ·), so no
ordering of the exponent positions is definable there while the encoding fixes
one. `Succ` *is* derived — every ordinal has an immediate successor, so it is
first-order over the order, and it is deferred rather than built eagerly.

One sentence separates the two engines: in ω² the limits are the ω·k and none of
them is a limit of limits, while in ω^ω the ordinal ω² is one. The tests also
cross-check the constructions where they overlap — ω² sits inside ω^ω, built
once by interpreting Büchi arithmetic and once from hand-written tree automata,
agreeing pointwise. Incidentally that sentence costs 0.1s on `TreeOrdinal(1)`,
0.5s on `Ordinal(2)` and 38.7s on `Ordinal(3)`: the word-engine cost climbs
steeply with the interpretation dimension while the tree encoding stays flat.

## Also here

- **The sentence bug, tree side.** The tree engine had the same gap the string
  engine had: a subformula with no free variables evaluates to the all/none
  marker, whose single tape is a placeholder rather than a variable, and both
  connective branches tried to rename it into the enclosing tape order, so
  `(all x. φ) & (all y. ψ)` raised `IndexError` here too. Fixed the same way,
  with a cross-engine test that both answer the same sentences alike.

- **Quotients stay string-only, and now say why accurately.** Representatives
  are not missing — every tree-automatic equivalence has a regular complete
  system of them (Colcombet & Löding), computable in polynomial space with
  exponentially many states (Kuske & Weidner, MFCS 2011, Thm 3.1). What fails is
  the string engine's route: taking the least element of a class needs
  well-foundedness, and while a tree-automatic linear order exists, growing a
  tree at the deciding position makes it smaller, so a class need have no least
  element. Kuske and Weidner minimize instead over a class's *descriptions*, a
  non-empty finite subset, at a provably unavoidable exponential cost. The
  `NotImplementedError` names all of that; meanwhile a caller who wants a
  quotient over trees names the representatives with a formula ρ and passes
  `domain = δ ∧ ρ`, which is the same construction with the choice explicit.

## Testing

Full suite green: **680 passed, 5 skipped**. The tree fold gets a randomized
language-preservation test over automata with a non-power-of-two alphabet, where
the diagram is genuinely rebuilt; the interpretations and the ordinals are each
checked against a Python oracle.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
