### PR TITLE
The countable atomless boolean algebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ batch:
 | package | structures |
 |---------|------------|
 | `autstr.arithmetic`, `autstr.buildin` | Presburger and Büchi arithmetic (ℤ, +, <, \|₂), Skolem arithmetic (ℕ, ·), the MSO0 finite-powerset structure |
-| `autstr.algebra` | the localizations **ℤ[1/p]**, finite **Boolean algebras** |
+| `autstr.algebra`, `autstr.tree_algebra` | the localizations **ℤ[1/p]**, finite **Boolean algebras**, and the countable **atomless Boolean algebra** |
 | `autstr.infinite_graphs`, `autstr.ordinals`, `autstr.turing` | the **integer grid** ℤⁿ, the **regular tree** T_k, the **ordinals** below ω^ω and — on the tree engine — below ω^(ω^ω), **Turing-machine configuration graphs** |
 
 **Classes** — one automaton for a whole family, indexed by advice:

--- a/autstr/symbolic/expr.py
+++ b/autstr/symbolic/expr.py
@@ -15,6 +15,7 @@ silently meaning addition.
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from typing import Any, Iterable, List, Sequence, Tuple, Union
 
 
@@ -173,6 +174,31 @@ class Var(Term):
         return self.name
 
 
+def _hashable(value):
+    """A hashable stand-in for a Python value.
+
+    An element codec may accept any Python value, and for some structures the
+    natural one is a set or a map — a clopen set is a set of cylinders, an
+    ordinal a map from exponent to coefficient. Those are unhashable, but a
+    constant has to sit in the dictionaries the compiler keys by subterm, so
+    they get a canonical stand-in instead. Equal values give equal stand-ins,
+    which is what the hash/equality contract needs; unequal values may collide,
+    which costs nothing, since equality itself still compares the values.
+    """
+    if isinstance(value, (set, frozenset)):
+        return 'set', tuple(sorted(map(_hashable, value), key=repr))
+    if isinstance(value, Mapping):
+        return 'map', tuple(sorted(((_hashable(k), _hashable(v))
+                                    for k, v in value.items()), key=repr))
+    if isinstance(value, (list, tuple)):
+        return 'seq', tuple(map(_hashable, value))
+    try:
+        hash(value)
+    except TypeError:
+        return 'repr', repr(value)
+    return value
+
+
 class Const(Term):
     """A Python value, encoded through the signature's codec."""
 
@@ -181,6 +207,10 @@ class Const(Term):
     def __init__(self, ctx, value):
         super().__init__(ctx, (value,))
         object.__setattr__(self, 'value', value)
+
+    def __hash__(self):
+        return hash((type(self).__name__, id(self.ctx),
+                     _hashable(self.value)))
 
     def variables(self):
         return []

--- a/autstr/tree_algebra.py
+++ b/autstr/tree_algebra.py
@@ -1,0 +1,235 @@
+"""The countable atomless boolean algebra, as a tree-automatic structure.
+
+There is exactly one countable atomless boolean algebra up to isomorphism —
+Cantor's back-and-forth argument again — and it is the infinite counterpart of
+the `autstr.algebra.FiniteBooleanAlgebras` class, carrying the same signature
+``Leq``, ``Meet``, ``Join``, ``Compl``, ``Atom``. The same formula runs against
+both, and the one that separates them is the definition of the name: over a
+finite algebra ``exists x. Atom(x)`` is true, and here it is false.
+
+**Elements are clopen subsets of Cantor space.** A clopen subset of
+:math:`2^\\omega` is a finite union of cylinders, so it is decided by finitely
+many bits of a point — that is, by a finite binary decision tree with leaves
+labelled in or out. Making the tree *reduced* (no split whose two sides are the
+same constant) makes the encoding a bijection, which matters here: a
+non-canonical encoding would need a quotient, and quotients are exactly what
+the tree engine cannot yet supply (see `autstr.interpretations`).
+
+**One authored automaton.** Reduction is what makes the order cheap. In a
+reduced tree a subtree is constant exactly when it is a leaf, so at any
+position the comparison is already decided unless *both* sides split there::
+
+    x is 0 here            -> fine, nothing of x to contain
+    y is 1 here            -> fine, y contains everything
+    x is 1, y is not       -> y misses a point of x
+    y is 0, x is not       -> x has a point y misses
+    both split             -> recurse
+
+Nothing below a leaf is ever consulted, so ``Leq`` is a two-state bottom-up
+automaton. Everything else — ``Meet``, ``Join``, ``Compl``, ``Atom``, and
+equality — is first-order over it and is defined rather than authored, built
+the first time a query asks for it.
+
+    >>> B = AtomlessBooleanAlgebra()
+    >>> x, y = B.symbolic().vars("x y")
+    >>> (x * y).eq({'00'}).check()          # some meet is the cylinder 00
+    True
+    >>> B.check('exists x.(Atom(x))')       # atomless, by construction
+    False
+
+A clopen set is written as the set of binary strings whose cylinders it
+contains: ``{'0', '10'}`` is everything starting ``0`` or ``10``, ``set()`` is
+empty and ``{''}`` is everything. Any covering set may be given — ``{'0','1'}``
+and ``{''}`` denote the same element — and `decode` returns the canonical one.
+"""
+from __future__ import annotations
+
+import itertools
+from typing import FrozenSet, Iterable, Optional
+
+from autstr.sparse_tree_automata import SparseTreeAutomaton, Tree
+from autstr.symbolic import FunctionCodec, Signature
+from autstr.tree_presentations import TreeAutomaticPresentation
+from autstr.utils.misc import encode_symbol
+
+#: a clopen set, as the binary strings whose cylinders it contains
+Clopen = Iterable[str]
+
+
+class AtomlessBooleanAlgebra(TreeAutomaticPresentation):
+    """The unique countable atomless boolean algebra.
+
+    :param max_states: optional cap on the subset determinizations inside
+        projection.
+
+    Elements are the clopen subsets of Cantor space, encoded as reduced binary
+    decision trees: ``'0'`` and ``'1'`` label leaves that are out and in, and
+    ``'n'`` labels a split on the next bit of a point.
+    """
+
+    #: split, out-leaf, in-leaf, padding
+    SPLIT, OUT, IN, PAD = 'n', '0', '1', '*'
+    LETTERS = frozenset({SPLIT, OUT, IN, PAD})
+
+    #: `x` is the bottom / the top, spelled out so that the definitions below
+    #: stay first-order over `Leq` alone
+    _BOTTOM = 'all v.(Leq({0},v))'
+    _TOP = 'all v.(Leq(v,{0}))'
+
+    def __init__(self, max_states: Optional[int] = None) -> None:
+        super().__init__({'U': self._universe(), 'Leq': self._order()},
+                         padding_symbol=self.PAD, max_states=max_states)
+        bottom, top = self._BOTTOM, self._TOP
+        self._declare_deferred({
+            # antisymmetry is equality, as in the finite algebras
+            'Eq': 'Leq(x,y) & Leq(y,x)',
+            # the greatest lower bound, and dually the least upper bound
+            'Meet': ('Leq(z,x) & Leq(z,y) & '
+                     'all w.((Leq(w,x) & Leq(w,y)) -> Leq(w,z))'),
+            'Join': ('Leq(x,z) & Leq(y,z) & '
+                     'all w.((Leq(x,w) & Leq(y,w)) -> Leq(z,w))'),
+            # y is the complement of x: they meet in the bottom and join to
+            # the top
+            'Compl': (f'(all w.((Leq(w,x) & Leq(w,y)) -> {bottom.format("w")}))'
+                      f' & (all w.((Leq(x,w) & Leq(y,w)) -> '
+                      f'{top.format("w")}))'),
+            # nothing lies strictly between an atom and the bottom -- here the
+            # relation is empty, which is the whole point
+            'Atom': (f'(not {bottom.format("x")}) & '
+                     f'all y.(Leq(y,x) -> ({bottom.format("y")} | Leq(x,y)))'),
+        })
+
+    def default_signature(self):
+        """Meet as ``*``, join as ``+``, complement as unary ``-``, the order
+        as ``.leq`` and equality as ``.eq``.
+
+        The lattice operations are terms, not connectives: ``&``, ``|`` and
+        ``~`` already mean conjunction, disjunction and negation of *formulas*,
+        so binding them here would make ``x & y`` ambiguous — the same reason
+        `autstr.arithmetic` spells its divisibility relation
+        ``divided_by_power``.
+        """
+        signature = Signature(codec=FunctionCodec(self.encode, self.decode))
+        signature.function('meet', graph='Meet', out=2)
+        signature.function('join', graph='Join', out=2)
+        signature.function('compl', graph='Compl', out=1)
+        signature.operator('*', 'meet')
+        signature.operator('+', 'join')
+        signature.operator('-', 'compl')
+        signature.operator('leq', 'Leq')
+        signature.operator('eq', 'Eq')
+        # the operations are built on first use, so their arities cannot be
+        # read off automata that do not exist yet
+        signature.relations = {'Meet': 3, 'Join': 3, 'Compl': 2, 'Eq': 2,
+                               'Atom': 1}
+        return signature
+
+    def is_atomless(self) -> bool:
+        """Whether every non-empty element strictly contains a non-empty one —
+        decidable, being first-order, and the property that pins the algebra
+        down to isomorphism."""
+        bottom = self._BOTTOM
+        return self.check(
+            f'all x.((not {bottom.format("x")}) -> exists y.('
+            f'(not {bottom.format("y")}) & Leq(y,x) & (not Leq(x,y))))')
+
+    def __repr__(self):
+        return "<AtomlessBooleanAlgebra>"
+
+    # ---------------- encoding elements ----------------
+    def encode(self, clopen: Clopen) -> Tree:
+        """The reduced decision tree of a clopen set, written as the binary
+        strings whose cylinders it contains. Any covering set is accepted and
+        canonicalized."""
+        cylinders = frozenset(clopen)
+        for cylinder in cylinders:
+            if set(cylinder) - {self.OUT, self.IN}:
+                raise ValueError(
+                    f"{cylinder!r} is not a binary string, so it names no "
+                    f"cylinder of Cantor space")
+        return self._reduce(cylinders, '')
+
+    def decode(self, tree: Tree) -> FrozenSet[str]:
+        """The clopen set a tree encodes, as its canonical cylinders."""
+        found = set()
+
+        def walk(node, prefix):
+            if node is None:
+                raise ValueError("not a decision tree")
+            if node.label == self.IN:
+                found.add(prefix)
+            elif node.label == self.SPLIT:
+                walk(node.left, prefix + self.OUT)
+                walk(node.right, prefix + self.IN)
+            elif node.label != self.OUT:
+                raise ValueError(f"{node.label!r} labels no decision node")
+
+        walk(tree, '')
+        return frozenset(found)
+
+    def _reduce(self, cylinders: FrozenSet[str], prefix: str) -> Tree:
+        """The reduced tree of `cylinders` below `prefix`: a leaf as soon as
+        the answer is settled, and a split only where it is not."""
+        if any(prefix.startswith(cylinder) for cylinder in cylinders):
+            return Tree(self.IN)                  # inside one of them already
+        if not any(cylinder.startswith(prefix) for cylinder in cylinders):
+            return Tree(self.OUT)                 # none of them reaches here
+        left = self._reduce(cylinders, prefix + self.OUT)
+        right = self._reduce(cylinders, prefix + self.IN)
+        if left.left is None and right.left is None and \
+                left.label == right.label:
+            return Tree(left.label)               # a split that decides nothing
+        return Tree(self.SPLIT, left, right)
+
+    # ---------------- the automata ----------------
+    @classmethod
+    def _enc(cls, letters) -> int:
+        return encode_symbol(tuple(letters), cls.LETTERS)
+
+    @classmethod
+    def _universe(cls) -> SparseTreeAutomaton:
+        """The reduced decision trees — one per clopen set. A split whose two
+        sides are the same constant is the one thing forbidden; it would give
+        that constant a second encoding."""
+        out, in_, split, dead = 0, 1, 2, 3
+        bot = 4
+        exc = [(bot, bot, (cls.OUT,), out), (bot, bot, (cls.IN,), in_)]
+        exc += [(left, right, (cls.SPLIT,), split)
+                for left, right in itertools.product((out, in_, split),
+                                                     repeat=2)
+                if (left, right) not in ((out, out), (in_, in_))]
+        return SparseTreeAutomaton(
+            4, dead,
+            [e[0] for e in exc], [e[1] for e in exc],
+            [cls._enc(e[2]) for e in exc], [e[3] for e in exc],
+            [True, True, True, False], 1, set(cls.LETTERS))
+
+    @classmethod
+    def _order(cls) -> SparseTreeAutomaton:
+        """Containment. Because the trees are reduced, a subtree is constant
+        exactly when it is a leaf, so a leaf on either side settles the whole
+        cylinder and nothing below it is ever consulted."""
+        ok, bad, bot = 0, 1, 2
+
+        def verdict(one: str, other: str, below_left: int,
+                    below_right: int) -> int:
+            if one == cls.PAD or other == cls.PAD:
+                return ok                  # settled by a leaf further up
+            if one == cls.OUT or other == cls.IN:
+                return ok                  # x is empty here, or y is full
+            if one == cls.IN or other == cls.OUT:
+                return bad                 # x has a point that y misses
+            return ok if below_left == ok == below_right else bad
+
+        exc = [(left, right, (one, other),
+                verdict(one, other, ok if left == bot else left,
+                        ok if right == bot else right))
+               for left in (ok, bad, bot) for right in (ok, bad, bot)
+               for one in sorted(cls.LETTERS) for other in sorted(cls.LETTERS)]
+        exc = [e for e in exc if e[3] == ok]       # the default is a failure
+
+        return SparseTreeAutomaton(
+            2, bad,
+            [e[0] for e in exc], [e[1] for e in exc],
+            [cls._enc(e[2]) for e in exc], [e[3] for e in exc],
+            [True, False], 2, set(cls.LETTERS))

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -514,3 +514,30 @@ def test_a_signature_carries_its_codec():
     codec = FunctionCodec(_encode, _decode)
     assert order_signature({'Lt'}, codec=codec).codec is codec
     assert graph_signature({'E'}, codec=codec).codec is codec
+
+
+# ----------------------------------------------------------------------
+# constants whose Python value is not hashable
+# ----------------------------------------------------------------------
+
+def test_a_constant_may_be_a_set_or_a_map(S):
+    """An element codec may accept any Python value, and for some structures
+    the natural one is a set (a clopen set of cylinders) or a map (an ordinal
+    as exponent to coefficient). Constants sit in the dictionaries the compiler
+    keys by subterm, so they must hash even then."""
+    for value in [{1, 2}, {'a': 1, 'b': 2}, [1, 2], frozenset({3})]:
+        assert isinstance(hash(S.term(value)), int)
+
+
+def test_equal_unhashable_constants_agree(S):
+    # equal values must land in the same bucket, whatever order they were
+    # written in
+    assert S.term({'a': 1, 'b': 2}) == S.term({'b': 2, 'a': 1})
+    assert hash(S.term({'a': 1, 'b': 2})) == hash(S.term({'b': 2, 'a': 1}))
+    assert S.term({1, 2}) == S.term({2, 1})
+    assert hash(S.term({1, 2})) == hash(S.term({2, 1}))
+
+
+def test_distinct_unhashable_constants_stay_distinct(S):
+    assert S.term({1, 2}) != S.term({1, 3})
+    assert S.term({'a': 1}) != S.term({'a': 2})

--- a/tests/test_tree_algebra.py
+++ b/tests/test_tree_algebra.py
@@ -1,0 +1,189 @@
+"""The countable atomless boolean algebra.
+
+The oracle is Python's set algebra. A clopen subset of Cantor space is decided
+by finitely many bits of a point, so restricting to points of a fixed depth
+turns every element of the sample space into an ordinary finite set of binary
+strings, and meet, join, complement and containment become set operations on
+those.
+"""
+import itertools
+
+import pytest
+
+from autstr.algebra import FiniteBooleanAlgebras
+from autstr.sparse_tree_automata import Tree
+from autstr.tree_algebra import AtomlessBooleanAlgebra
+
+#: deep enough to separate every element of SPACE below
+DEPTH = 4
+
+#: clopen sets, written as the cylinders they contain
+SPACE = [set(), {''}, {'0'}, {'1'}, {'00'}, {'01'}, {'0', '10'},
+         {'00', '11'}, {'000', '01', '1'}, {'10'}, {'0', '11'}]
+
+
+@pytest.fixture(scope="module")
+def algebra():
+    return AtomlessBooleanAlgebra()
+
+
+def points(clopen, depth: int = DEPTH):
+    """The points of the given depth the clopen set contains — its extension,
+    as a plain finite set."""
+    return {word for word in map(''.join, itertools.product('01', repeat=depth))
+            if any(word.startswith(cylinder) for cylinder in clopen)}
+
+
+EVERYTHING = points({''})
+
+
+class TestCodec:
+    def test_roundtrip(self, algebra):
+        for clopen in SPACE:
+            assert points(algebra.decode(algebra.encode(clopen))) == \
+                points(clopen), clopen
+
+    def test_the_empty_set_and_the_whole_space(self, algebra):
+        assert algebra.encode(set()) == Tree('0')
+        assert algebra.encode({''}) == Tree('1')
+        assert algebra.decode(Tree('0')) == frozenset()
+        assert algebra.decode(Tree('1')) == frozenset([''])
+
+    def test_any_covering_set_is_canonicalized(self, algebra):
+        # the two halves are the whole space, and a split that decides nothing
+        # collapses
+        assert algebra.encode({'0', '1'}) == algebra.encode({''})
+        assert algebra.encode({'110', '111'}) == algebra.encode({'11'})
+        assert algebra.decode(algebra.encode({'0', '1'})) == frozenset([''])
+
+    def test_a_redundant_cylinder_is_absorbed(self, algebra):
+        assert algebra.encode({'0', '01'}) == algebra.encode({'0'})
+
+    def test_a_non_binary_string_is_rejected(self, algebra):
+        with pytest.raises(ValueError, match="cylinder"):
+            algebra.encode({'02'})
+
+
+class TestUniverse:
+    """One tree per clopen set: the reduced ones."""
+
+    def test_accepts_every_encoding(self, algebra):
+        for clopen in SPACE:
+            assert algebra.automata['U'].accepts(algebra.encode(clopen))
+
+    def test_rejects_a_split_that_decides_nothing(self, algebra):
+        # both sides out, and both sides in: each is a second encoding of a
+        # constant, so neither is an element
+        assert not algebra.automata['U'].accepts(
+            Tree('n', Tree('0'), Tree('0')))
+        assert not algebra.automata['U'].accepts(
+            Tree('n', Tree('1'), Tree('1')))
+        assert algebra.automata['U'].accepts(Tree('n', Tree('0'), Tree('1')))
+
+
+class TestOperationsAgainstSetAlgebra:
+    def test_containment(self, algebra):
+        order = algebra.automata['Leq']
+        for x, y in itertools.product(SPACE, repeat=2):
+            assert order.accepts(algebra.encode(x), algebra.encode(y)) == \
+                (points(x) <= points(y)), (x, y)
+
+    @pytest.mark.parametrize("name,operation",
+                             [('Meet', lambda a, b: a & b),
+                              ('Join', lambda a, b: a | b)])
+    def test_meet_and_join(self, algebra, name, operation):
+        algebra.materialize()
+        relation = algebra.automata[name]
+        for x, y, z in itertools.product(SPACE, repeat=3):
+            want = operation(points(x), points(y)) == points(z)
+            assert relation.accepts(*map(algebra.encode, (x, y, z))) == want, \
+                (name, x, y, z)
+
+    def test_complement(self, algebra):
+        algebra.materialize()
+        relation = algebra.automata['Compl']
+        for x, y in itertools.product(SPACE, repeat=2):
+            want = (EVERYTHING - points(x)) == points(y)
+            assert relation.accepts(algebra.encode(x),
+                                    algebra.encode(y)) == want, (x, y)
+
+
+class TestTermSurface:
+    """Meet, join and complement are terms — ``*``, ``+`` and unary ``-`` —
+    because ``&``, ``|`` and ``~`` already mean the connectives of the logic."""
+
+    def test_operations_as_terms(self, algebra):
+        x, y = algebra.symbolic().vars('x y')
+        meet = (x * y).eq({'00'}).evaluate()
+        assert meet.contains(x={'0'}, y={'00', '11'})
+        assert not meet.contains(x={'0'}, y={'1'})
+
+        join = (x + y).eq({''}).evaluate()
+        assert join.contains(x={'0'}, y={'1'})
+        assert not join.contains(x={'0'}, y={'00'})
+
+        complement = (-x).eq(y).evaluate()
+        assert complement.contains(x={'0'}, y={'1'})
+        assert not complement.contains(x={'0'}, y={'0'})
+
+    def test_the_order_as_a_method(self, algebra):
+        x, y = algebra.symbolic().vars('x y')
+        order = x.leq(y).evaluate()
+        assert order.contains(x={'00'}, y={'0'})
+        assert not order.contains(x={'0'}, y={'00'})
+
+    @pytest.mark.parametrize("law", ['idempotent', 'commutative', 'absorption',
+                                     'distributive', 'involution', 'de morgan'])
+    def test_the_axioms_hold(self, algebra, law):
+        x, y, z = algebra.symbolic().vars('x y z')
+        laws = {
+            'idempotent': (x * x).eq(x).all('x'),
+            'commutative': (x * y).eq(y * x).all('x y'),
+            'absorption': (x * (x + y)).eq(x).all('x y'),
+            'distributive': (x * (y + z)).eq((x * y) + (x * z)).all('x y z'),
+            'involution': (-(-x)).eq(x).all('x'),
+            'de morgan': (-(x * y)).eq((-x) + (-y)).all('x y'),
+        }
+        assert laws[law].check()
+
+
+class TestAtomless:
+    """The property the algebra is named for, and the one that pins it down:
+    a countable atomless boolean algebra is unique up to isomorphism."""
+
+    def test_it_is_atomless(self, algebra):
+        assert algebra.is_atomless()
+
+    def test_the_atom_relation_is_empty(self, algebra):
+        assert not algebra.check('exists x.(Atom(x))')
+
+    def test_the_same_sentence_separates_it_from_the_finite_algebras(
+            self, algebra):
+        """`Atom` is in both signatures, so one sentence tells them apart —
+        every finite boolean algebra has an atom and this one has none."""
+        finite = FiniteBooleanAlgebras()
+        assert finite.check('exists x.(Atom(x))', 4)
+        assert not algebra.check('exists x.(Atom(x))')
+
+    def test_it_has_a_bottom_and_a_top(self, algebra):
+        assert algebra.check('exists x.(all y.(Leq(x,y)))')
+        assert algebra.check('exists x.(all y.(Leq(y,x)))')
+
+    def test_every_element_has_a_complement(self, algebra):
+        assert algebra.check('all x.(exists y.(Compl(x,y)))')
+
+    def test_the_order_is_a_partial_order(self, algebra):
+        assert algebra.check('all x.(Leq(x,x))')
+        assert algebra.check(
+            'all x.(all y.(all z.((Leq(x,y) & Leq(y,z)) -> Leq(x,z))))')
+        assert algebra.check(
+            'all x.(all y.((Leq(x,y) & Leq(y,x)) -> Eq(x,y)))')
+
+
+class TestConstruction:
+    def test_repr(self, algebra):
+        assert repr(algebra) == "<AtomlessBooleanAlgebra>"
+
+    def test_the_signature_matches_the_finite_algebras(self, algebra):
+        assert sorted(algebra.get_relation_symbols()) == \
+            ['Atom', 'Compl', 'Eq', 'Join', 'Leq', 'Meet', 'U']


### PR DESCRIPTION
The last of the ordinary Tier II structures: the countable atomless boolean
algebra, the infinite counterpart of `FiniteBooleanAlgebras`.

There is exactly one such algebra up to isomorphism, and it carries the same
signature as the finite class — `Leq`, `Meet`, `Join`, `Compl`, `Atom` — so the
same formula runs against both. The one that separates them is the definition of
the name: over a finite algebra `exists x. Atom(x)` is true, and here it is
false. That is a test.

## The encoding does the work

Elements are the clopen subsets of Cantor space. Such a set is decided by
finitely many bits of a point, so it *is* a finite binary decision tree with
leaves labelled in or out. Making the tree **reduced** — no split whose two
sides are the same constant — makes the encoding a bijection.

That mattered concretely rather than aesthetically: a non-canonical encoding
would have needed a quotient, which is exactly what the tree engine cannot yet
supply (see the `_quotient` docstring, merged in #40). This structure lands on
the right side of that limitation by construction.

Reduction is also what makes the order cheap. In a reduced tree a subtree is
constant exactly when it is a leaf, so at any position the comparison is already
settled unless *both* sides split there:

```
x is 0 here            -> fine, nothing of x to contain
y is 1 here            -> fine, y contains everything
x is 1, y is not       -> y misses a point of x
y is 0, x is not       -> x has a point y misses
both split             -> recurse
```

Nothing below a leaf is ever consulted, so `Leq` is a **two-state** bottom-up
automaton and `U` is five. Meet, join, complement, the atom predicate and
equality are all first-order over `Leq`, defined rather than authored and built
the first time a query asks for one.

## The surface

Meet, join and complement bind to `*`, `+` and unary `-`. They are terms, not
connectives — `&`, `|` and `~` already mean conjunction, disjunction and
negation of *formulas*, so binding those would make `x & y` ambiguous, the same
reason `autstr.arithmetic` spells its divisibility relation
`divided_by_power`.

```python
B = AtomlessBooleanAlgebra()
x, y, z = B.symbolic().vars("x y z")

(x * (y + z)).eq((x * y) + (x * z)).all("x y z").check()   # distributive
(-(x * y)).eq((-x) + (-y)).all("x y").check()              # de Morgan
B.is_atomless()                                            # True
B.check("exists x.(Atom(x))")                              # False
```

A clopen set is written as the binary strings whose cylinders it contains:
`{'0', '10'}` is everything starting `0` or `10`, `set()` is empty and `{''}` is
everything. Any covering set is accepted and canonicalized — `{'0','1'}` and
`{''}` denote the same element — and `decode` returns the canonical one.

## A generic fix that came out of it

Writing a constant into a formula required the Python value to be **hashable**,
so `(x * y).eq({'00'})` raised `TypeError`. An element codec may accept any
value, and for some structures the natural one is unhashable: a clopen set is a
set of cylinders, an ordinal a map from exponent to coefficient. Constants sit
in the dictionaries the compiler keys by subterm, so they have to hash.

This was latent for the tree ordinals too — their elements are dicts; nothing
had yet written one into a formula rather than passing it to `contains`. `Const`
now hashes a canonical stand-in, with equality still comparing the values
themselves, so equal values collide by design and unequal ones may collide
harmlessly.

## Testing

The oracle is Python's own set algebra: restricting to points of a fixed depth
turns every element of the sample space into an ordinary finite set of binary
strings, and meet, join, complement and containment become set operations on
those, checked exhaustively over the sample space (cubed, for the ternary
relations). Plus the boolean axioms through the term surface, the canonical-form
rejections, and the separating sentence against `FiniteBooleanAlgebras`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
