### PR TITLE
Reachability for level 2 collapsible pushdown graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ batch:
 | `autstr.arithmetic`, `autstr.buildin` | Presburger and Büchi arithmetic (ℤ, +, <, \|₂), Skolem arithmetic (ℕ, ·), the MSO0 finite-powerset structure |
 | `autstr.algebra`, `autstr.tree_algebra` | the localizations **ℤ[1/p]**, finite **Boolean algebras**, and the countable **atomless Boolean algebra** |
 | `autstr.infinite_graphs`, `autstr.ordinals`, `autstr.turing` | the **integer grid** ℤⁿ, the **regular tree** T_k, the **ordinals** below ω^ω and — on the tree engine — below ω^(ω^ω), **Turing-machine configuration graphs** |
-| `autstr.collapsible` | **level 2 collapsible pushdown graphs** — tree-automatic by Kartzow's encoding, and the one automatic route to them, since their MSO theory is undecidable |
+| `autstr.collapsible`, `autstr.collapsible_reach` | **level 2 collapsible pushdown graphs** — tree-automatic by Kartzow's encoding, and the one automatic route to them, since their MSO theory is undecidable. **Reachability** is a relation of the graph, so first-order formulas may ask about runs of any length — the question a Turing machine's configuration graph cannot answer |
 
 **Classes** — one automaton for a whole family, indexed by advice:
 

--- a/autstr/collapsible.py
+++ b/autstr/collapsible.py
@@ -45,15 +45,24 @@ structure tree-automatic without a quotient.
 
 **Reachability, and the contrast with Turing machines.** For a level 2
 collapsible pushdown graph the reachability relation is itself tree-automatic
-(Kartzow, Prop. 5.1), so first-order logic *with* reachability is decidable
-here — the very question that `autstr.turing` cannot answer, since for a
-configuration graph of a Turing machine reachability is the halting problem.
-That construction is not implemented: it is exponential in the number of
-control states and takes up the bulk of the paper, whereas everything below is
-elementary. This module presents the one-step relation, over *all*
-configurations rather than only those reachable from an initial one — the same
-reading Kartzow's result takes, and the only one available without the
-reachability construction.
+(Kartzow, Prop. 5.1), and it is built here — ``Reach`` is a relation of the
+graph like any other, so a first-order formula may ask about runs of any
+length. That is the very question `autstr.turing` cannot answer, since for a
+configuration graph of a Turing machine reachability is the halting problem. It
+is also the reason these graphs belong on the tree engine at all::
+
+    >>> 'Reach' in graph.get_relation_symbols()
+    True
+
+`reach_along` gives the sharper version: reachability along runs whose labels a
+finite automaton accepts, which is Kartzow's ``Reach_L`` and covers the
+ε-contraction of the graph as the case of any number of silent labels followed
+by one other. The construction is in `autstr.collapsible_reach`; it is
+exponential in the number of control states, so ``Reach`` is declared but not
+built until a query asks for it.
+
+Configurations are *all* of them, not only those reachable from an initial
+one — the same reading Kartzow's result takes.
 
 References:
 
@@ -354,14 +363,19 @@ class _Encoding:
     ACCEPT = 'accept'
 
     def __init__(self, states: Sequence[str], symbols: Sequence[str],
-                 bottom: str) -> None:
+                 bottom: str, extra_states: Sequence[str] = ()) -> None:
         self.bottom_label = f'{bottom}:1'
         #: the labels of letter nodes: the bottom symbol carries a level 1
         #: link and never occurs anywhere but at the bottom
         self.letters = [self.bottom_label] + [
             f'{symbol}:{level}' for symbol in symbols if symbol != bottom
             for level in (1, 2)]
-        self.states = [f'<{state}>' for state in states]
+        # `extra_states` are root letters for configurations of another
+        # system over the same stacks — a product with a label automaton, say,
+        # which has to be related to the plain configurations tree by tree
+        self.states = [f'<{state}>' for state in states] + \
+            [f'<{state}>' for state in extra_states
+             if state not in set(states)]
         #: everything that can label a node of a stack tree
         self.nodes = self.letters + [SEP]
         self.alphabet = set(self.nodes) | set(self.states) | {PAD}
@@ -863,6 +877,10 @@ class Level2CPG:
             'Pop1': encoding.pop1,
             'Pop2': encoding.pop2,
             'Collapse': self._collapse,
+            # reachability is in the signature from the start, but the
+            # automaton is exponential in the number of control states, so it
+            # is built the first time a query actually asks for it
+            'Reach': self._reach,
             **{self.push_names[symbol, level]:
                (lambda symbol=symbol, level=level:
                 encoding.push(symbol, level))
@@ -903,6 +921,31 @@ class Level2CPG:
         table[('stack', None, (f'<{state}>',))] = encoding.ACCEPT
         return partial_tree_automaton(encoding.alphabet, 1, table,
                                       {encoding.ACCEPT})
+
+    def _reach(self):
+        """Reachability: a run of any length between two configurations.
+
+        Decidable here, and *not* over a Turing machine's configuration graph,
+        where the same question is halting — the difference this whole module
+        exists to show. The construction is Kartzow's; see
+        `autstr.collapsible_reach`.
+        """
+        from autstr.collapsible_reach import Relations
+        return Relations(self.system).reach()
+
+    def reach_along(self, name: str, labels) -> None:
+        """Install ``Reach_L``: reachability along runs whose labels the
+        given `autstr.collapsible_reach.LabelAutomaton` accepts.
+
+        Plain reachability is the case where every label word is allowed, and
+        an ε-contraction is the case of any number of silent labels followed by
+        one other — so this one relation covers both.
+
+        :param name: the relation symbol to install it under.
+        :param labels: which sequences of labels a run may read.
+        """
+        from autstr.collapsible_reach import regular_reach
+        self.presentation.update(**{name: regular_reach(self.system, labels)})
 
     def _collapse(self):
         """``collapse``, at either link level: on a level 2 link the stack is

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -43,7 +43,7 @@ top.
 through µ-calculus model checking on collapsible pushdown graphs, which is a
 decision procedure of its own. It is not needed: the decomposition lemmas the
 paper proves are already a closed system of rules, each saying how one kind of
-run is built from shorter ones —
+run is built from shorter ones::
 
     return      = high loop, then a pop, or a drop into the word below
                   followed by a return of it, or a pushed level 2 letter
@@ -54,7 +54,7 @@ run is built from shorter ones —
     1-loop      = loop, clone, loop, clone, …
     loop        = high loop, or high loop then low loop then high loop
 
-— and the least fixpoint of those rules is the summary. The rules refer to the
+The least fixpoint of those rules is the summary. The rules refer to the
 summaries of *longer* words, which is why this is one simultaneous fixpoint
 over the whole table rather than an induction on word length.
 

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -1,8 +1,28 @@
-"""Returns and loops of a level 2 collapsible pushdown system.
+"""Reachability in a level 2 collapsible pushdown graph.
 
-Reachability in a collapsible pushdown graph is built out of four kinds of run
-(Kartzow 2013, §4), all of them concerned with what a stack can do *before* it
-drops below where it started:
+Whether one configuration can reach another is decidable here, and that is the
+point of the whole encoding: over a Turing machine's configuration graph the
+same question is halting. Kartzow proves the relation tree-automatic; this
+builds it.
+
+**Reach = A ; B ; C ; D.** Every run splits into four stretches — words come
+off the stack, then letters, then letters go back on, then words — and all four
+relations are reflexive, so the composition excludes nothing. Reachability is
+therefore a first-order formula over the four rather than an automaton of its
+own, and `Relations.reach` writes it out. `regular_reach` gives Kartzow's
+sharper ``Reach_L``, along runs whose labels a finite automaton accepts, by
+building that automaton into a product system; an ε-contraction is the case of
+any number of silent labels followed by one other.
+
+Each of the four is checked on four tapes: the two configurations, the summary
+annotation of one of them, and a guessed control state per node. The annotation
+is what lets a bottom-up automaton consult a computation that runs top-down —
+a node carries the summary of the word read from the root down to it, which is
+a local check — and both scaffolding tapes are quantified away afterwards.
+
+**The summaries** are what all of that rests on. Four kinds of run matter
+(Kartzow 2013, §4), all concerned with what a stack can do *before* it drops
+below where it started:
 
 * a **return** takes a stack to the one below it,
 * a **loop** takes a stack back to itself, and splits into a **high loop**,
@@ -52,11 +72,13 @@ Tree-Automatic*, LMCS 9(1), 2013, §4.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, FrozenSet, Optional, Tuple
+from typing import Dict, FrozenSet, Optional, Sequence, Tuple
 
 from autstr.collapsible import PAD, SEP, Level2CPS
 from autstr.sparse_tree_automata import SparseTreeAutomaton, Tree
-from autstr.utils.tree_automata_tools import partial_tree_automaton
+from autstr.utils.tree_automata_tools import (
+    minimize, partial_tree_automaton,
+)
 
 #: a relation on control states
 Relation = FrozenSet[Tuple[str, str]]
@@ -526,11 +548,12 @@ class Relations:
     #: regions would otherwise want the same entry
     BURIED = '@buried'
 
-    def __init__(self, system: Level2CPS, summaries: Optional[Summaries] = None
-                 ) -> None:
+    def __init__(self, system: Level2CPS, summaries: Optional[Summaries] = None,
+                 extra_states: Sequence[str] = ()) -> None:
         from autstr.collapsible import _Encoding
         self.system = system
-        self.encoding = _Encoding(system.states, system.symbols, system.bottom)
+        self.encoding = _Encoding(system.states, system.symbols, system.bottom,
+                                  extra_states)
         self.summaries = summaries or Summaries(system)
         self.annotation = Annotation(self.encoding, self.summaries)
         # a letter the run drops carries the states it is in before and after
@@ -1273,3 +1296,135 @@ class Relations:
         return scratch.evaluate(
             'exists u.(exists v.(exists w.('
             'A(x,u) & B(u,v) & C(v,w) & D(w,y))))')
+
+
+# ----------------------------------------------------------------------
+# reachability along a regular set of label words
+# ----------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class LabelAutomaton:
+    """A finite automaton over a system's edge labels.
+
+    It says which sequences of labels a run may read, which is what turns
+    plain reachability into Kartzow's regular reachability ``Reach_L``.
+
+    :param transitions: ``(state, label, state)`` triples; several may share a
+        state and label, so the automaton need not be deterministic.
+    :param initial: the state a run starts in.
+    :param final: the states a run may end in.
+    """
+    transitions: Tuple[Tuple[str, str, str], ...]
+    initial: str
+    final: FrozenSet[str]
+
+    @staticmethod
+    def of_word(labels) -> 'LabelAutomaton':
+        """Runs reading exactly this sequence of labels."""
+        steps = tuple((f'p{index}', label, f'p{index + 1}')
+                      for index, label in enumerate(labels))
+        return LabelAutomaton(steps, 'p0', frozenset({f'p{len(steps)}'}))
+
+    @staticmethod
+    def anything(labels) -> 'LabelAutomaton':
+        """Runs reading any sequence at all — plain reachability."""
+        return LabelAutomaton(tuple(('p', label, 'p') for label in labels),
+                              'p', frozenset({'p'}))
+
+    @staticmethod
+    def contracting(labels, silent) -> 'LabelAutomaton':
+        """Runs reading any number of `silent` labels and then one other —
+        the step relation of an ε-contraction."""
+        steps = [('p', label, 'p') for label in silent]
+        steps += [('p', label, 'q') for label in labels if label not in silent]
+        return LabelAutomaton(tuple(steps), 'p', frozenset({'q'}))
+
+    @property
+    def states(self):
+        found = {self.initial} | set(self.final)
+        for source, _, target in self.transitions:
+            found |= {source, target}
+        return sorted(found)
+
+
+def product(system: Level2CPS, labels: LabelAutomaton) -> Level2CPS:
+    """The system whose runs are those of `system` whose labels `labels`
+    accepts, its control state carrying both.
+
+    Kartzow builds the label automaton into the reachability automaton
+    directly; as a product system it is the same thing said once, and it costs
+    nothing beyond the states multiplying.
+    """
+    rules = []
+    for rule in system.rules:
+        for source, label, target in labels.transitions:
+            if label != rule.label:
+                continue
+            rules.append((f'{rule.state}|{source}', rule.symbol, rule.label,
+                          f'{rule.target}|{target}', rule.operation))
+    return Level2CPS(rules, bottom=system.bottom,
+                     initial_state=f'{system.initial_state}|{labels.initial}',
+                     states=[f'{state}|{other}' for state in system.states
+                             for other in labels.states],
+                     symbols=system.symbols)
+
+
+def relabel_root(encoding, source: str, target: str) -> SparseTreeAutomaton:
+    """Two configurations with the same stack, whose control states are the
+    two given ones — the trees agree everywhere but at the root."""
+    table = {}
+    for label in encoding.nodes:
+        for left in (None, 'same'):
+            for right in (None, 'same'):
+                table[(left, right, (label, label))] = 'same'
+    table[('same', None, (f'<{source}>', f'<{target}>'))] = 'accept'
+    return partial_tree_automaton(encoding.alphabet, 2, table, {'accept'})
+
+
+def regular_reach(system: Level2CPS, labels: LabelAutomaton,
+                  summaries: Optional[Summaries] = None
+                  ) -> SparseTreeAutomaton:
+    """``Reach_L``: reachability along runs whose labels `labels` accepts.
+
+    The label automaton goes into a product system, whose reachability is the
+    ordinary one; what remains is to say that the two configurations are the
+    plain ones underneath — same stack, control state tagged with the label
+    automaton's initial state at one end and an accepting one at the other::
+
+        Reach_L(x,y) ≡ ∃u ∃v. Tag_{p₀}(x,u) ∧ Reach(u,v) ∧ ⋁_f Tag_f(y,v)
+
+    Both kinds of configuration live in the same structure for the length of
+    that formula, which is why the encoding carries root letters for both, and
+    the alphabet is narrowed again once the tags are quantified away.
+    """
+    from autstr.tree_presentations import TreeAutomaticPresentation
+    from autstr.utils.tree_automata_tools import restrict_alphabet
+    both = product(system, labels)
+    relations = Relations(both, summaries, extra_states=system.states)
+    encoding = relations.encoding
+
+    tags, names = {}, {}
+    for index, state in enumerate(labels.states):
+        pairs = [relabel_root(encoding, plain, f'{plain}|{state}')
+                 for plain in system.states]
+        joined = pairs[0]
+        for other in pairs[1:]:
+            joined = minimize(joined.union(other))
+        names[state] = f'Tag{index}'
+        tags[f'Tag{index}'] = joined
+
+    scratch = TreeAutomaticPresentation(
+        {'U': encoding.universe(), 'Reach': relations.reach(), **tags},
+        padding_symbol=PAD)
+    accepting = ' | '.join(f'{names[state]}(y,v)' for state in
+                           sorted(labels.final) if state in names)
+    result = scratch.evaluate(
+        f'exists u.(exists v.({names[labels.initial]}(x,u) & Reach(u,v) '
+        f'& ({accepting})))')
+    plain = _Encoding_of(system)
+    return restrict_alphabet(result, plain.alphabet)
+
+
+def _Encoding_of(system: Level2CPS):
+    from autstr.collapsible import _Encoding
+    return _Encoding(system.states, system.symbols, system.bottom)

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -1,0 +1,316 @@
+"""Returns and loops of a level 2 collapsible pushdown system.
+
+Reachability in a collapsible pushdown graph is built out of four kinds of run
+(Kartzow 2013, §4), all of them concerned with what a stack can do *before* it
+drops below where it started:
+
+* a **return** takes a stack to the one below it,
+* a **loop** takes a stack back to itself, and splits into a **high loop**,
+  which never drops a letter, and a **low loop**, which drops exactly one and
+  writes it back,
+* a **1-loop** takes a stack to one with the same topmost word and more words
+  underneath.
+
+The pivotal fact is that which of these exist depends only on the stack's
+**topmost word** — not on anything below it. So each word `w` has a *summary*:
+four relations on the control states, saying between which states a return, a
+high loop, a low loop and a 1-loop of `w` exist. Kartzow's Prop. 4.20 then says
+the summary of `wσ` is determined by the summary of `w` together with σ, which
+makes the summaries the states of a finite automaton reading a word bottom to
+top.
+
+**How this computes them.** The paper's own effectiveness argument routes
+through µ-calculus model checking on collapsible pushdown graphs, which is a
+decision procedure of its own. It is not needed: the decomposition lemmas the
+paper proves are already a closed system of rules, each saying how one kind of
+run is built from shorter ones —
+
+    return      = high loop, then a pop, or a drop into the word below
+                  followed by a return of it, or a pushed level 2 letter
+                  collapsed after a 1-loop
+    high loop   = (push, loop of the longer word, pop) and (clone, return),
+                  closed under composition
+    low loop    = drop a level 1 letter, loop of the word below, write it back
+    1-loop      = loop, clone, loop, clone, …
+    loop        = high loop, or high loop then low loop then high loop
+
+— and the least fixpoint of those rules is the summary. The rules refer to the
+summaries of *longer* words, which is why this is one simultaneous fixpoint
+over the whole table rather than an induction on word length.
+
+**Why all four together.** A level 2 letter pushed at width d carries a link to
+width d−1, and a clone copies the letter *with its link*, so collapsing it from
+the copy drops two words at once — overshooting the copy's own return. Such a
+run is no composition of two returns, and what covers it is exactly a 1-loop:
+push the letter, let the stack grow underneath while the topmost word comes
+back, then collapse. Returns therefore need 1-loops, which need loops, which
+need returns.
+
+Reference: A. Kartzow, *Collapsible Pushdown Graphs of Level 2 are
+Tree-Automatic*, LMCS 9(1), 2013, §4.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, Optional, Tuple
+
+from autstr.collapsible import Level2CPS
+
+#: a relation on control states
+Relation = FrozenSet[Tuple[str, str]]
+
+#: a letter of a word, as the summaries see it: a symbol and a link level. The
+#: link *value* is always zero here — a summary is asked of a word on its own,
+#: where a link into the stack below means nothing.
+Letter = Tuple[str, int]
+
+
+def compose(left: Relation, right: Relation) -> Relation:
+    """The relational composition ``left ; right``."""
+    if not left or not right:
+        return frozenset()
+    targets: Dict[str, set] = {}
+    for source, middle in right:
+        targets.setdefault(source, set()).add(middle)
+    return frozenset((source, target)
+                     for source, middle in left
+                     for target in targets.get(middle, ()))
+
+
+def closure(relation: Relation, states) -> Relation:
+    """The reflexive transitive closure."""
+    result = relation | frozenset((state, state) for state in states)
+    while True:
+        grown = result | compose(result, result)
+        if grown == result:
+            return result
+        result = grown
+
+
+@dataclass(frozen=True)
+class Summary:
+    """What the runs of one word are, between which control states.
+
+    :param symbol: the word's topmost symbol.
+    :param level: the link level of its topmost letter.
+    :param ret: pairs (q, q') with a return — a run to the stack below.
+    :param hloop: pairs with a high loop — back to the same stack, never
+        dropping the topmost letter.
+    :param lloop: pairs with a low loop — dropping the topmost letter and
+        writing it back.
+    :param oneloop: pairs with a 1-loop — back to the same topmost word, with
+        more words underneath.
+    """
+    symbol: Optional[str] = None
+    level: int = 0
+    ret: Relation = frozenset()
+    hloop: Relation = frozenset()
+    lloop: Relation = frozenset()
+    oneloop: Relation = frozenset()
+
+    @property
+    def loop(self) -> Relation:
+        """Every loop: a high loop, or a high loop, a low loop and a high loop
+        in sequence (Kartzow, Cor. 4.17)."""
+        return self.hloop | compose(compose(self.hloop, self.lloop),
+                                    self.hloop)
+
+    def relations(self):
+        return self.ret, self.hloop, self.lloop, self.oneloop
+
+
+#: the summary of the empty word: nothing below the bottom letter, so no run of
+#: any kind, and no letter to drop onto
+EMPTY = Summary()
+
+
+class Summaries:
+    """The summaries of the words a system can build.
+
+    The rules for a word's runs refer to the runs of *longer* words — pushing a
+    letter and dropping it again is how a run stays where it is — so this is
+    one simultaneous least fixpoint rather than an induction on length. The
+    fixpoint is taken over the words themselves, up to a length bound, with
+    everything longer treated as having no runs at all.
+
+    That makes the result an **under-approximation**: every run it reports is
+    real, and one it misses would need a word longer than the bound to be
+    written down. The bound is raised until the summaries stop changing, which
+    is where the fixpoint has been reached — for the automaton of Kartzow's
+    Prop. 4.20 the summaries of long words repeat, so this terminates on the
+    systems it is meant for, and `converged` says whether it did.
+
+    :param system: the collapsible pushdown system.
+    :param depth: how many letters above the bottom to unroll before raising
+        the bound; raised up to `limit` while the summaries keep growing.
+    :param limit: the longest word the fixpoint will consider.
+    """
+
+    def __init__(self, system: Level2CPS, depth: int = 3,
+                 limit: int = 7) -> None:
+        self.system = system
+        self.states = list(system.states)
+        self.letters = [(symbol, level) for symbol in system.symbols
+                        if symbol != system.bottom for level in (1, 2)]
+        self.bottom = (system.bottom, 1)
+        self._moves = {symbol: self._transitions(symbol)
+                       for symbol in system.symbols}
+        self.converged = False
+        self.values: Dict[tuple, Summary] = {}
+        self.depth = depth
+        previous_bound = 0
+        for bound in range(depth, limit + 1):
+            previous, self.values = self.values, self._fixpoint(bound)
+            self.depth = bound
+            # the longest words of a round are the ones whose own extensions
+            # were pinned empty, so they always improve when the bound rises;
+            # convergence is about the words below that edge
+            if previous and all(
+                    previous[path] == self.values[path] for path in previous
+                    if len(path) < previous_bound):
+                self.converged = True
+                break
+            previous_bound = bound
+
+    # -- the transitions available on one topmost symbol ----------------
+    def _transitions(self, symbol: str) -> Dict[object, Relation]:
+        """The moves of the system when `symbol` is on top, by operation."""
+        moves: Dict[object, set] = {}
+        for rule in self.system.rules:
+            if rule.symbol is not None and rule.symbol != symbol:
+                continue
+            operation = rule.operation
+            if operation.kind == 'push':
+                key = ('push', operation.symbol, operation.level)
+            elif operation.kind == 'pop':
+                key = f'pop{operation.level}'
+            else:
+                key = operation.kind
+            moves.setdefault(key, set()).add((rule.state, rule.target))
+        return {key: frozenset(pairs) for key, pairs in moves.items()}
+
+    def moves(self, symbol: str, key) -> Relation:
+        return self._moves.get(symbol, {}).get(key, frozenset())
+
+    def drops(self, letter: Letter) -> Relation:
+        """The moves that remove the topmost letter: a pop of level 1, and a
+        collapse when the link is of level 1 — a level 1 link always points at
+        the preceding letter, so collapsing on one is popping it."""
+        symbol, level = letter
+        dropped = self.moves(symbol, 'pop1')
+        if level == 1:
+            dropped |= self.moves(symbol, 'collapse')
+        return dropped
+
+    # -- the fixpoint ---------------------------------------------------
+    def _paths(self, bound: int):
+        """Every word of at most `bound` letters above the bottom one."""
+        paths, frontier = [(self.bottom,)], [(self.bottom,)]
+        for _ in range(bound):
+            frontier = [path + (letter,) for path in frontier
+                        for letter in self.letters]
+            paths.extend(frontier)
+        return paths
+
+    def _fixpoint(self, bound: int) -> Dict[tuple, Summary]:
+        """The least fixpoint of the rules over the words of that length.
+
+        Every rule is monotone in the summaries it reads, so starting from "no
+        runs at all" and applying them until nothing changes climbs to the
+        least fixpoint — which is the true summary for every word whose runs
+        stay within the bound.
+        """
+        values = {path: Summary(path[-1][0], path[-1][1])
+                  for path in self._paths(bound)}
+        while True:
+            grown = {}
+            for path, current in values.items():
+                below = values[path[:-1]] if len(path) > 1 else EMPTY
+                grown[path] = self._solve(below, path, values, current)
+            if grown == values:
+                return values
+            values = grown
+
+    def of_word(self, word) -> Summary:
+        """The summary of a word, given as its letters from the bottom up."""
+        path = tuple((symbol, level) for symbol, level in word)
+        if path not in self.values:
+            raise ValueError(
+                f"the fixpoint was taken over words of up to {self.depth} "
+                f"letter(s) above the bottom, which {path} exceeds")
+        return self.values[path]
+
+    def _solve(self, below: Summary, path: tuple, values: Dict[tuple, Summary],
+               current: Summary) -> Summary:
+        """One round of the rules for the word `path`.
+
+        `below` is the summary of the word without its topmost letter, and
+        `values` supplies the longer words — a letter pushed on top of this one
+        makes a word one longer, and what that word's runs are is what says
+        whether the letter can be pushed and dropped again.
+        """
+        symbol, level = path[-1]
+        drop = self.drops(path[-1])             # remove this letter
+        clone = self.moves(symbol, 'clone')
+        pop2 = self.moves(symbol, 'pop2')
+        pushes = [(key, pairs) for key, pairs in self._moves.get(
+            symbol, {}).items() if isinstance(key, tuple)]
+        longer = {key: values.get(path + ((key[1], key[2]),), EMPTY)
+                  for key, _ in pushes}
+
+        # a high loop: push a letter, loop on the longer word, and drop it
+        # again; or clone, and return the copy
+        high = compose(clone, current.ret)
+        for key, pairs in pushes:
+            high |= compose(compose(pairs, longer[key].loop),
+                            self.drops((key[1], key[2])))
+        high = closure(high, self.states)
+
+        # a low loop drops this letter -- only a level 1 link may be dropped
+        # and written back as it was -- loops below, and writes it back
+        low = frozenset()
+        if level == 1 and below is not EMPTY:
+            low = compose(compose(drop, below.loop),
+                          self.moves(below.symbol, ('push', symbol, 1)))
+
+        # a 1-loop leaves the stack taller than it found it, with the topmost
+        # word back as it was. The growth may happen here, by cloning this
+        # word; above, by pushing a letter and growing under the longer word
+        # before dropping it again; or below, by dropping this letter and
+        # growing under the word beneath before writing it back.
+        loop = high | compose(compose(high, low), high)
+        grow = clone
+        for key, pairs in pushes:
+            grow |= compose(compose(pairs, longer[key].oneloop),
+                            self.drops((key[1], key[2])))
+        if level == 1 and below is not EMPTY:
+            grow |= compose(compose(drop, below.oneloop),
+                            self.moves(below.symbol, ('push', symbol, 1)))
+        # at least one of those, with loops in between and around
+        once = compose(compose(loop, grow), loop)
+        one = compose(once, closure(once, self.states))
+
+        # a return ends by popping the word, by dropping this letter and
+        # returning the word below, or by collapsing a level 2 letter pushed
+        # on top after the stack has grown underneath it
+        end = pop2 | compose(drop, below.ret)
+        for key, pairs in pushes:
+            inner = longer[key]
+            # pushing does not change the width, so a return of the longer
+            # word lands exactly where a return of this one has to
+            end |= compose(pairs, inner.ret)
+            if key[2] != 2:
+                continue                        # only a level 2 link collapses
+            # the letter points one word down, so collapsing it ends the
+            # return from wherever the stack has grown to -- or from right
+            # here, if it never grew
+            end |= compose(compose(pairs, inner.loop | inner.oneloop),
+                           self.moves(key[1], 'collapse'))
+        ret = compose(high, end)
+
+        return Summary(symbol, level, ret, high, low, one)
+
+    def __repr__(self):
+        return (f"<Summaries of {self.system!r}: {len(set(self.values.values()))}"
+                f" distinct over {len(self.values)} words, depth {self.depth}"
+                f"{'' if self.converged else ', not converged'}>")

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -644,23 +644,162 @@ class Relations:
                     table[('same', None, labels)] = 'accept'
         return partial_tree_automaton(self.alphabet, 4, table, {'accept'})
 
-    def without_scaffolding(self, checker: SparseTreeAutomaton
-                            ) -> SparseTreeAutomaton:
+    def without_scaffolding(self, checker: SparseTreeAutomaton,
+                            annotated: int = 0) -> SparseTreeAutomaton:
         """A four-tape checker as a relation on two configurations.
 
         The annotation is required to be the real one — that is what the
         annotation automaton says — and then both it and the guess are
         quantified away, leaving the alphabet to be narrowed back to the one
         the configurations are written in.
+
+        :param annotated: which configuration the annotation belongs to. The
+            words a run passes through are those of the *longer* of the two,
+            which is the first tape where letters come off and the second
+            where they go on.
         """
         from autstr.utils.tree_automata_tools import (
             attach_padding, expand, minimize, project, restrict_alphabet,
         )
         annotated = minimize(expand(minimize(attach_padding(
-            self.annotation.automaton(self.alphabet), PAD)), 4, [0, 2]))
+            self.annotation.automaton(self.alphabet), PAD)), 4,
+            [annotated, 2]))
         result = minimize(minimize(
             attach_padding(checker, PAD)).intersection(annotated))
         for tape in (3, 2):
             result = minimize(attach_padding(
                 project(result, tape, PAD), PAD))
         return restrict_alphabet(result, self.encoding.alphabet)
+
+    def looping(self, annotation: str, guess: str) -> bool:
+        """Whether the guess is a high loop of the word this node names."""
+        pair = self.guessed(guess)
+        summary = self.summary_of(annotation)
+        return pair is not None and summary is not None and \
+            pair in summary.hloop
+
+    def push_moves(self, annotation: str, label: str) -> Relation:
+        """The transitions that write `label` on a stack whose topmost word is
+        the one `annotation` names.
+
+        A pop is guarded by the letter it takes off, so a node can check it
+        alone; a push is guarded by the letter already on top, which is the one
+        *above* the letter written — and which is not this node's label when
+        the letter goes below a separator. The summary knows it either way: it
+        carries the topmost symbol of the word it names.
+        """
+        summary = self.summary_of(annotation)
+        written, _, level = label.rpartition(':')
+        if summary is None or summary.symbol is None or not level.isdigit():
+            return frozenset()
+        return self.summaries.moves(summary.symbol,
+                                    ('push', written, int(level)))
+
+    def c(self) -> SparseTreeAutomaton:
+        """``C``: the topmost word gains letters, and the run never dips below
+        where it started.
+
+        B read backwards, and the same tree shape with the two configurations
+        exchanged: the second one's last path is longer by a tail, and the
+        first carries the one separator the second loses. The run is a high
+        loop and a push at each letter gained — the loop belonging to the node
+        that names its word, the push to the node above, which is where the
+        letter it writes is still on top.
+        """
+        table = {}
+        annotations = list(self.annotation.names.values())
+        marks = [(label, annotation)
+                 for label in self.encoding.nodes for annotation in annotations]
+        letters = [label for label in self.encoding.letters]
+        states = self.system.states
+
+        def chain(kind, label, first, final):
+            return f'{kind}|{label}|{first}|{final}'
+
+        for label, annotation in marks:
+            for left in (None, 'same'):
+                for right in (None, 'same'):
+                    table[(left, right, (label, label, annotation, self.NONE))] \
+                        = 'same'
+        # the separator the first tree carries, where its last word ends, and
+        # the one the second loses
+        table[(None, None, (SEP, PAD, PAD, self.NONE))] = 'added'
+        for annotation in annotations:
+            table[(None, None, (PAD, SEP, annotation, self.NONE))] = 'cut'
+
+        # a letter the run pushes. The node checks the high loop of its own
+        # word; the push that put the letter there is checked by its parent.
+        for label, annotation in marks:
+            if label not in letters:
+                continue
+            for guess in self.guesses:
+                if not self.looping(annotation, guess):
+                    continue
+                first, last = self.guessed(guess)
+                symbols = (PAD, label, annotation, guess)
+                table[(None, None, symbols)] = chain('chain', label, first, last)
+                table[('cut', None, symbols)] = \
+                    chain('cutchain', label, first, last)
+                for below in letters:
+                    moves = self.push_moves(annotation, below)
+                    for entered, final in moves:
+                        if entered != last:
+                            continue
+                        for kind in ('chain', 'cutchain'):
+                            for deepest in states:
+                                table[(chain(kind, below, final, deepest), None,
+                                       symbols)] = \
+                                    chain(kind, label, first, deepest)
+
+        # a separator the second tree loses, on the way down the tail
+        for annotation in annotations:
+            symbols = (PAD, SEP, annotation, self.NONE)
+            for label in letters:
+                for first in states:
+                    for final in states:
+                        table[(chain('chain', label, first, final), None,
+                               symbols)] = chain('cutchain', label, first, final)
+                        table[(None, chain('chain', label, first, final),
+                               symbols)] = chain('cutchain', label, first, final)
+
+        # where the tail begins: one more high loop, then the push that starts
+        # it -- both belonging to this node, which both trees keep
+        for label, annotation in marks:
+            summary = self.summary_of(annotation)
+            plain = (label, label, annotation, self.NONE)
+            for below in letters:
+                moves = self.push_moves(annotation, below)
+                for entered, final in moves:
+                    for start in states:
+                        if (start, entered) not in summary.hloop:
+                            continue
+                        for kind, done in (('chain', 'done'),
+                                           ('cutchain', 'cutdone')):
+                            for deepest in states:
+                                source = chain(kind, below, final, deepest)
+                                target = f'{done} {start} {deepest}'
+                                table[(source, None, plain)] = target
+                                table[('same', source, plain)] = target
+                                table[(None, source, plain)] = target
+            for first in states:
+                for final in states:
+                    for kind in ('done', 'cutdone'):
+                        below_state = f'{kind} {first} {final}'
+                        table[(below_state, None, plain)] = below_state
+                        table[('same', below_state, plain)] = below_state
+                        table[(None, below_state, plain)] = below_state
+                    grown = f'grown {first} {final}'
+                    table[(f'cutdone {first} {final}', 'added', plain)] = grown
+                    table[(grown, None, plain)] = grown
+                    table[('same', grown, plain)] = grown
+                    table[(None, grown, plain)] = grown
+
+        for source in states:
+            for target in states:
+                labels = (f'<{source}>', f'<{target}>', Annotation.START,
+                          self.NONE)
+                for kind in ('done', 'grown'):
+                    table[(f'{kind} {source} {target}', None, labels)] = 'accept'
+                if source == target:
+                    table[('same', None, labels)] = 'accept'
+        return partial_tree_automaton(self.alphabet, 4, table, {'accept'})

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -54,7 +54,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, FrozenSet, Optional, Tuple
 
-from autstr.collapsible import Level2CPS
+from autstr.collapsible import SEP, Level2CPS
+from autstr.sparse_tree_automata import SparseTreeAutomaton, Tree
+from autstr.utils.tree_automata_tools import partial_tree_automaton
 
 #: a relation on control states
 Relation = FrozenSet[Tuple[str, str]]
@@ -159,9 +161,14 @@ class Summaries:
         self.values: Dict[tuple, Summary] = {}
         self.depth = depth
         previous_bound = 0
+        #: the words whose summary stopped growing when the bound last rose —
+        #: a value can only grow, so agreeing twice means it is the truth
+        self.stable: set = set()
         for bound in range(depth, limit + 1):
             previous, self.values = self.values, self._fixpoint(bound)
             self.depth = bound
+            self.stable = {path for path in previous
+                           if previous[path] == self.values[path]}
             # the longest words of a round are the ones whose own extensions
             # were pinned empty, so they always improve when the bound rises;
             # convergence is about the words below that edge
@@ -230,6 +237,53 @@ class Summaries:
             if grown == values:
                 return values
             values = grown
+
+    def transitions(self) -> Tuple[Summary, Dict[Tuple[Summary, Letter],
+                                                 Summary]]:
+        """The summaries as an automaton: the summary of the bottom letter,
+        and a table saying how one letter extends a summary.
+
+        This is the merge Kartzow's Prop. 4.20 licenses — words with the same
+        summary behave alike, so they are one state. Words at the edge of the
+        fixpoint are left out of the merge: their own extensions were pinned
+        empty, so what they say about a letter is not yet the truth.
+        """
+        if not self.converged:
+            raise ValueError(
+                f"the summaries were still growing at {self.depth} letters, so "
+                f"words that look alike need not behave alike yet; raise the "
+                f"limit")
+        # a word near the edge has its own extensions pinned empty, so what
+        # it says about a letter is short of the truth; only the words whose
+        # summary has stopped growing may speak
+        table: Dict[Tuple[Summary, Letter], Summary] = {}
+        for path in sorted(self.stable, key=len):
+            summary = self.values[path]
+            for letter in self.letters:
+                longer = self.values.get(path + (letter,))
+                if longer is None or path + (letter,) not in self.stable:
+                    continue
+                seen = table.setdefault((summary, letter), longer)
+                if seen != longer:
+                    raise ValueError(
+                        f"two words with the same summary disagree about the "
+                        f"letter {letter!r}, so the summaries do not determine "
+                        f"the automaton; raise the limit")
+        start = self.values[(self.bottom,)]
+
+        # the merge has to reproduce what the fixpoint computed
+        for path in self.stable:
+            summary = self.values[path]
+            walked = start
+            for letter in path[1:]:
+                walked = table.get((walked, letter))
+                if walked is None:
+                    break
+            if walked is not None and walked != summary:
+                raise ValueError(
+                    f"the merged automaton disagrees with the summary of "
+                    f"{path}; raise the limit")
+        return start, table
 
     def of_word(self, word) -> Summary:
         """The summary of a word, given as its letters from the bottom up."""
@@ -314,3 +368,102 @@ class Summaries:
         return (f"<Summaries of {self.system!r}: {len(set(self.values.values()))}"
                 f" distinct over {len(self.values)} words, depth {self.depth}"
                 f"{'' if self.converged else ', not converged'}>")
+
+
+# ----------------------------------------------------------------------
+# reading a word down the tree
+# ----------------------------------------------------------------------
+
+class Annotation:
+    """The summary of the word from the root of an encoding tree to each node,
+    written on a tape of its own.
+
+    Kartzow's automata ask, at a node `d`, which returns and loops the stack
+    that node stands for has — and that stack's topmost word is the word read
+    from the root *down* to `d`. A bottom-up automaton cannot read downwards,
+    so the answer is carried on a second tape, where the check becomes local: a
+    node's annotation is its parent's extended by the node's own letter, and a
+    separator carries its parent's along unchanged.
+
+    The tape is scaffolding — the construction pushes it through a projection
+    and then drops it, which is what
+    `autstr.utils.tree_automata_tools.restrict_alphabet` is for.
+
+    :param encoding: the tree alphabet of the system, from `autstr.collapsible`.
+    :param summaries: the summaries of that system's words.
+    """
+
+    #: the annotation of the root, where no letter has been read yet
+    START = '~start'
+
+    def __init__(self, encoding, summaries: Summaries) -> None:
+        self.encoding = encoding
+        self.summaries = summaries
+        first, table = summaries.transitions()
+        self.names = {}
+        for summary in [first] + [value for _, value in sorted(
+                table.items(), key=lambda item: repr(item[0]))]:
+            self.names.setdefault(summary, f'~{len(self.names)}')
+        #: annotation letter -> letter -> annotation letter
+        self.table = {(self.names[summary], letter): self.names[value]
+                      for (summary, letter), value in table.items()}
+        self.first = self.names[first]
+        self.letters = [self.START] + sorted(self.names.values())
+        self.alphabet = set(encoding.alphabet) | set(self.letters)
+
+    def extend(self, annotation: str, label: str) -> Optional[str]:
+        """The annotation a node carries, given its parent's and its own
+        label — or None where no encoding tree has that shape."""
+        if label == SEP:
+            return annotation                   # a separator reads no letter
+        if label not in self.encoding.letters:
+            return None                         # a state labels only the root
+        symbol, _, level = label.rpartition(':')
+        if annotation == self.START:
+            return self.first if label == self.encoding.bottom_label else None
+        return self.table.get((annotation, (symbol, int(level))))
+
+    def of_tree(self, tree, annotation: Optional[str] = None) -> Tree:
+        """The annotation of a configuration tree, as a tree of its own — the
+        oracle the automaton is checked against."""
+        annotation = self.START if annotation is None else annotation
+        here = annotation if tree.label in self.encoding.states \
+            else self.extend(annotation, tree.label)
+        if here is None:
+            raise ValueError(f"{tree.label!r} cannot follow {annotation!r}")
+        return Tree(here,
+                    self.of_tree(tree.left, here) if tree.left else None,
+                    self.of_tree(tree.right, here) if tree.right else None)
+
+    def automaton(self) -> SparseTreeAutomaton:
+        """Two tapes: a configuration tree, and its annotation.
+
+        A node's state is what a parent has to know about it — the annotation
+        it carries and the label it carries — since the parent is where the
+        two can be compared.
+        """
+        table = {}
+        pairs = [(label, annotation) for label in self.encoding.nodes
+                 for annotation in self.names.values()]
+        options = [None] + [f'{annotation}|{label}'
+                            for label, annotation in pairs]
+
+        def fits(parent: str, child) -> bool:
+            """Whether a child may hang below a node annotated `parent`."""
+            if child is None:
+                return True
+            annotation, _, label = child.partition('|')
+            return self.extend(parent, label) == annotation
+
+        for label, annotation in pairs:
+            for left in options:
+                for right in options:
+                    if fits(annotation, left) and fits(annotation, right):
+                        table[(left, right, (label, annotation))] = \
+                            f'{annotation}|{label}'
+        # the root carries the state and reads no letter of its own
+        for state in self.encoding.states:
+            for left in options:
+                if fits(self.START, left):
+                    table[(left, None, (state, self.START))] = 'accept'
+        return partial_tree_automaton(self.alphabet, 2, table, {'accept'})

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -971,3 +971,160 @@ class Relations:
             return False
         return any(rule.operation.kind == 'collapse'
                    for rule in self.system.rules)
+
+    def d(self) -> SparseTreeAutomaton:
+        """``D``: the stack grows, and the run never dips below where it
+        started.
+
+        Kartzow's Cor. 4.10 says such a run visits the milestones of the stack
+        it builds in order, consecutive ones joined by a single operation and a
+        loop — and the encoding puts those milestones in traversal order, one
+        per node. The run therefore only ever moves *forward* through the tree,
+        which is what decides where each operation goes: descending to a left
+        child is a push, and a new word is reached by cloning at the deepest
+        point of the word before it and then popping back up, one letter per
+        level, until the two words part company.
+
+        Cloning at the deepest point rather than where the words part is the
+        whole of it. The other way round would let a word be shorter than the
+        copy it came from for nothing, which is a run no system need have.
+        """
+        table = {}
+        annotations = list(self.annotation.names.values())
+        marks = [(label, annotation)
+                 for label in self.encoding.nodes for annotation in annotations]
+        letters = list(self.encoding.letters)
+        states = self.system.states
+
+        def grew(cloned, label, arrive, leave):
+            return f'grew|{int(cloned)}|{label}|{arrive}|{leave}'
+
+        for label, annotation in marks:
+            for left in (None, 'same'):
+                for right in (None, 'same'):
+                    table[(left, right, (label, label, annotation, self.NONE))] \
+                        = 'same'
+
+        for label, annotation in marks:
+            summary = self.summary_of(annotation)
+            if summary is None:
+                continue
+            loop = summary.loop
+            clones = self.summaries.moves(summary.symbol or '', 'clone')
+            for guess in self.guesses:
+                pair = self.guessed(guess)
+                if pair is None:
+                    continue
+                arrive, leave = pair
+                symbols = (PAD, label, annotation, guess)
+
+                # the deepest milestone of a word: the run loops there, and
+                # clones if another word is still to come
+                if (arrive, leave) in loop:
+                    table[(None, None, symbols)] = \
+                        grew(False, label, arrive, leave)
+                if (arrive, leave) in compose(loop, clones):
+                    table[(None, None, symbols)] = \
+                        grew(True, label, arrive, leave)
+
+                for below in letters:
+                    symbol, _, level = below.rpartition(':')
+                    down = compose(loop, self.push_moves(annotation, below))
+                    up = compose(self.drop_moves(symbol, int(level)), loop)
+                    for entered in states:
+                        if (arrive, entered) not in down:
+                            continue
+                        for came_back in states:
+                            # deeper and never back: this word is the last
+                            child = grew(False, below, entered, came_back)
+                            if came_back == leave:
+                                table[(child, None, symbols)] = \
+                                    grew(False, label, arrive, leave)
+                            # deeper, cloned down there, and popping back up
+                            cloned = grew(True, below, entered, came_back)
+                            if (came_back, leave) in up:
+                                table[(cloned, None, symbols)] = \
+                                    grew(True, label, arrive, leave)
+                            # ... until the words part, where the new one
+                            # hangs as this node's right child
+                            for last in states:
+                                sibling = grew(False, SEP, leave, last)
+                                if (came_back, leave) in up:
+                                    table[(cloned, sibling, symbols)] = \
+                                        grew(False, label, arrive, last)
+                                shared = grew(True, SEP, leave, last)
+                                if (came_back, leave) in up:
+                                    table[(cloned, shared, symbols)] = \
+                                        grew(True, label, arrive, last)
+
+                # a word that parts from this one right here: the clone
+                # happened below, and nothing was popped since
+                for last in states:
+                    for kind in (False, True):
+                        sibling = grew(kind, SEP, leave, last)
+                        if (arrive, leave) in compose(loop, clones):
+                            table[(None, sibling, symbols)] = \
+                                grew(kind, label, arrive, last)
+
+        # Where the growth hangs, and the run starts. The first new word is
+        # a clone of the one this node names, and this is the only place that
+        # clone can be checked -- inside the region every node is one the
+        # second tree alone has.
+        for label, annotation in marks:
+            summary = self.summary_of(annotation)
+            plain = (label, label, annotation, self.NONE)
+            if summary is None:
+                continue
+            starts = compose(summary.loop,
+                             self.summaries.moves(summary.symbol or '', 'clone'))
+            for arrive in states:
+                for last in states:
+                    child = grew(False, SEP, arrive, last)
+                    for first in states:
+                        if (first, arrive) not in starts:
+                            continue
+                        done = f'done {first} {last}'
+                        for other in (None, 'same'):
+                            table[(other, child, plain)] = done
+                        table[(child, None, plain)] = done
+            for first in states:
+                for last in states:
+                    done = f'done {first} {last}'
+                    table[(done, None, plain)] = done
+                    table[('same', done, plain)] = done
+                    table[(None, done, plain)] = done
+
+        for source in states:
+            for target in states:
+                labels = (f'<{source}>', f'<{target}>', Annotation.START,
+                          self.NONE)
+                table[(f'done {source} {target}', None, labels)] = 'accept'
+                if source == target:
+                    table[('same', None, labels)] = 'accept'
+        return partial_tree_automaton(self.alphabet, 4, table, {'accept'})
+
+    def reach(self) -> SparseTreeAutomaton:
+        """Reachability: a run of any length, between any two configurations.
+
+        Kartzow's Remark 4.4 splits every run into four stretches — words come
+        off, then letters, then letters go back on, then words — and each is
+        reflexive, so no run is excluded by having to pass through all four.
+        The relation is therefore the composition, which is a first-order
+        formula over the four and needs no automaton of its own::
+
+            Reach(x,y) ≡ ∃u ∃v ∃w. A(x,u) ∧ B(u,v) ∧ C(v,w) ∧ D(w,y)
+
+        The quantifiers range over configurations, so the domain of the scratch
+        structure is the encoding trees themselves.
+        """
+        from autstr.tree_presentations import TreeAutomaticPresentation
+        scratch = TreeAutomaticPresentation(
+            {'U': self.encoding.universe(),
+             'A': self.without_scaffolding(self.a()),
+             'B': self.without_scaffolding(self.b()),
+             'C': self.without_scaffolding(self.c(), annotated=1),
+             'D': self.without_scaffolding(self.d(), annotated=1)},
+            padding_symbol=PAD)
+        return scratch.evaluate(
+            'exists u.(exists v.(exists w.('
+            'A(x,u) & B(u,v) & C(v,w) & D(w,y))))')

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, FrozenSet, Optional, Tuple
 
-from autstr.collapsible import SEP, Level2CPS
+from autstr.collapsible import PAD, SEP, Level2CPS
 from autstr.sparse_tree_automata import SparseTreeAutomaton, Tree
 from autstr.utils.tree_automata_tools import partial_tree_automaton
 
@@ -435,8 +435,12 @@ class Annotation:
                     self.of_tree(tree.left, here) if tree.left else None,
                     self.of_tree(tree.right, here) if tree.right else None)
 
-    def automaton(self) -> SparseTreeAutomaton:
+    def automaton(self, alphabet=None) -> SparseTreeAutomaton:
         """Two tapes: a configuration tree, and its annotation.
+
+        :param alphabet: the alphabet to build over, when a construction has
+            letters of its own beside these — an automaton can only be
+            combined with others that read the same one.
 
         A node's state is what a parent has to know about it — the annotation
         it carries and the label it carries — since the parent is where the
@@ -466,4 +470,197 @@ class Annotation:
             for left in options:
                 if fits(self.START, left):
                     table[(left, None, (state, self.START))] = 'accept'
-        return partial_tree_automaton(self.alphabet, 2, table, {'accept'})
+        return partial_tree_automaton(alphabet or self.alphabet, 2,
+                                      table, {'accept'})
+
+
+# ----------------------------------------------------------------------
+# the relations Reach decomposes into
+# ----------------------------------------------------------------------
+
+class Relations:
+    """The relations whose composition is reachability.
+
+    Kartzow's Remark 4.4 splits every run into four stretches: `A` drops whole
+    words, `B` drops letters from the topmost word, `C` pushes letters back on,
+    and `D` grows the stack again. All four are reflexive, so reachability is
+    their composition and needs no automaton of its own —
+
+        Reach(x,y) ≡ ∃d ∃e ∃f. A(x,d) ∧ B(d,e) ∧ C(e,f) ∧ D(f,y)
+
+    which is a formula the engine evaluates once the four are installed.
+
+    Each is checked on four tapes — the two configurations, the summary
+    annotation of the first, and a guessed control state per node — and the
+    last two are projected away afterwards.
+
+    :param system: the collapsible pushdown system.
+    :param summaries: its summaries; computed if not given.
+    """
+
+    #: a node no run visits, and so carries no guessed states
+    NONE = '@-'
+
+    def __init__(self, system: Level2CPS, summaries: Optional[Summaries] = None
+                 ) -> None:
+        from autstr.collapsible import _Encoding
+        self.system = system
+        self.encoding = _Encoding(system.states, system.symbols, system.bottom)
+        self.summaries = summaries or Summaries(system)
+        self.annotation = Annotation(self.encoding, self.summaries)
+        # a letter the run drops carries the states it is in before and after
+        # dropping it, which is what makes every check local
+        self.guesses = [self.NONE] + [
+            f'@{before},{after}' for before in system.states
+            for after in system.states]
+        self.alphabet = set(self.annotation.alphabet) | set(self.guesses)
+
+    def summary_of(self, annotation: str) -> Optional[Summary]:
+        """The summary an annotation letter stands for."""
+        for summary, name in self.annotation.names.items():
+            if name == annotation:
+                return summary
+        return None
+
+    def drop_moves(self, symbol: str, level: int) -> Relation:
+        """The transitions that take the topmost letter off: a pop of level 1,
+        and a collapse when the link is of level 1."""
+        moves = self.summaries.moves(symbol, 'pop1')
+        if level == 1:
+            moves |= self.summaries.moves(symbol, 'collapse')
+        return moves
+
+    def guessed(self, guess: str) -> Optional[Tuple[str, str]]:
+        """The pair of states a guess letter carries, or None."""
+        if guess == self.NONE:
+            return None
+        before, _, after = guess[1:].partition(',')
+        return before, after
+
+    def dropping(self, annotation: str, label: str, guess: str) -> bool:
+        """Whether a letter may be dropped as the guess says: a high loop of
+        the word ending at it, then one transition that takes it off.
+
+        The word is the one read from the root down to this node, which is
+        what the annotation names — so the check needs nothing but this node's
+        own four tapes.
+        """
+        pair = self.guessed(guess)
+        summary = self.summary_of(annotation)
+        if pair is None or summary is None or label not in self.encoding.letters:
+            return False
+        symbol, _, level = label.rpartition(':')
+        return pair in compose(summary.hloop,
+                               self.drop_moves(symbol, int(level)))
+
+    def b(self) -> SparseTreeAutomaton:
+        """``B``: the topmost word loses letters, and nothing goes below what
+        is left.
+
+        The two trees agree except along a tail of the first one's last path,
+        which is deleted; the second may gain a single separator where its own
+        last word now ends. Climbing that tail is the run: at each letter a
+        high loop and one drop, the state after one drop being the state before
+        the next.
+        """
+        table = {}
+        annotations = list(self.annotation.names.values())
+        marks = [(label, annotation)
+                 for label in self.encoding.nodes for annotation in annotations]
+        pairs = [(before, after) for before in self.system.states
+                 for after in self.system.states]
+
+        # the two trees agree here and no run step happens
+        for label, annotation in marks:
+            for left in (None, 'same'):
+                for right in (None, 'same'):
+                    table[(left, right, (label, label, annotation, self.NONE))] \
+                        = 'same'
+        # the separator the second tree gains, where its last word now ends.
+        # One is added exactly when one is deleted -- the last word\'s
+        # divergence from the word below it moves up -- and never more.
+        table[(None, None, (PAD, SEP, PAD, self.NONE))] = 'added'
+
+        # below the deepest letter dropped, the old last separator goes
+        for annotation in annotations:
+            table[(None, None, (SEP, PAD, annotation, self.NONE))] = 'cut'
+
+        # a letter the run drops: the deepest starts the chain, each one above
+        # continues it, and a deleted separator sets the chain\'s mark
+        for label, annotation in marks:
+            for guess in self.guesses:
+                if not self.dropping(annotation, label, guess):
+                    continue
+                first, last = self.guessed(guess)
+                symbols = (label, PAD, annotation, guess)
+                table[(None, None, symbols)] = f'chain {first} {last}'
+                table[('cut', None, symbols)] = f'cutchain {first} {last}'
+                for start_state in self.system.states:
+                    for kind in ('chain', 'cutchain'):
+                        table[(f'{kind} {start_state} {first}', None,
+                               symbols)] = f'{kind} {start_state} {last}'
+            if label != SEP:
+                continue
+            for first, last in pairs:
+                # a separator on the way marks the chain; a second one would
+                # mean two words ended there, which no chain of pops does
+                symbols = (SEP, PAD, annotation, self.NONE)
+                table[(f'chain {first} {last}', None, symbols)] = \
+                    f'cutchain {first} {last}'
+                table[(None, f'chain {first} {last}', symbols)] = \
+                    f'cutchain {first} {last}'
+
+        # the chain stops at a node both trees keep. From there up nothing may
+        # follow it in either tree: coming from a right child anything already
+        # read may sit to the left, but coming from a left child there must be
+        # no right child at all.
+        for label, annotation in marks:
+            plain = (label, label, annotation, self.NONE)
+            for first, last in pairs:
+                for chain, kind in ((f'chain {first} {last}', 'done'),
+                                    (f'cutchain {first} {last}', 'cutdone')):
+                    for below in (chain, f'{kind} {first} {last}'):
+                        table[(below, None, plain)] = f'{kind} {first} {last}'
+                        table[('same', below, plain)] = f'{kind} {first} {last}'
+                        table[(None, below, plain)] = f'{kind} {first} {last}'
+                # the deleted separator is made good by the added one
+                for below in (f'cutchain {first} {last}',
+                              f'cutdone {first} {last}'):
+                    table[(below, 'added', plain)] = f'grown {first} {last}'
+                grown = f'grown {first} {last}'
+                table[(grown, None, plain)] = grown
+                table[('same', grown, plain)] = grown
+                table[(None, grown, plain)] = grown
+
+        # the root: the states the run began and ended in are the two
+        # configurations\' own, and a run of no steps leaves the tree alone
+        for source in self.system.states:
+            for target in self.system.states:
+                labels = (f'<{source}>', f'<{target}>', Annotation.START,
+                          self.NONE)
+                for kind in ('done', 'grown'):
+                    table[(f'{kind} {source} {target}', None, labels)] = 'accept'
+                if source == target:
+                    table[('same', None, labels)] = 'accept'
+        return partial_tree_automaton(self.alphabet, 4, table, {'accept'})
+
+    def without_scaffolding(self, checker: SparseTreeAutomaton
+                            ) -> SparseTreeAutomaton:
+        """A four-tape checker as a relation on two configurations.
+
+        The annotation is required to be the real one — that is what the
+        annotation automaton says — and then both it and the guess are
+        quantified away, leaving the alphabet to be narrowed back to the one
+        the configurations are written in.
+        """
+        from autstr.utils.tree_automata_tools import (
+            attach_padding, expand, minimize, project, restrict_alphabet,
+        )
+        annotated = minimize(expand(minimize(attach_padding(
+            self.annotation.automaton(self.alphabet), PAD)), 4, [0, 2]))
+        result = minimize(minimize(
+            attach_padding(checker, PAD)).intersection(annotated))
+        for tape in (3, 2):
+            result = minimize(attach_padding(
+                project(result, tape, PAD), PAD))
+        return restrict_alphabet(result, self.encoding.alphabet)

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -803,3 +803,87 @@ class Relations:
                 if source == target:
                     table[('same', None, labels)] = 'accept'
         return partial_tree_automaton(self.alphabet, 4, table, {'accept'})
+
+    def a_returns(self) -> SparseTreeAutomaton:
+        """``A`` as far as returns take it: the stack loses whole words, one
+        return each.
+
+        Kartzow's Lemma 4.11 decomposes a run of ``A`` into pieces that are
+        returns (F1), or a 1-loop followed by a level 2 collapse (F2), or a
+        1-loop followed by a pop that some later F2 closes off (F3). This
+        builds the F1 case. It is all of ``A`` for a system whose runs never
+        collapse on a level 2 link, since F2 and F3 both end in one; where they
+        can occur this under-approximates, and `collapses_on_links` says so.
+
+        The words the stack drops are the separators of the encoding, and the
+        run pops them from the last backwards — so within a subtree the chain
+        runs through the right child's separators, then the left child's, then
+        the node itself, which is reverse traversal order.
+        """
+        table = {}
+        annotations = list(self.annotation.names.values())
+        marks = [(label, annotation)
+                 for label in self.encoding.nodes for annotation in annotations]
+        states = self.system.states
+
+        for label, annotation in marks:
+            for left in (None, 'same'):
+                for right in (None, 'same'):
+                    table[(left, right, (label, label, annotation, self.NONE))] \
+                        = 'same'
+
+        # inside a word the first tree drops, nothing is guessed
+        for label, annotation in marks:
+            for left in (None, 'gone'):
+                for right in (None, 'gone'):
+                    table[(left, right, (label, PAD, annotation, self.NONE))] \
+                        = 'gone'
+
+        # a separator the first tree drops: one return of the word it names
+        for annotation in annotations:
+            summary = self.summary_of(annotation)
+            for guess in self.guesses:
+                pair = self.guessed(guess)
+                if pair is None or summary is None or pair not in summary.ret:
+                    continue
+                first, last = pair
+                symbols = (SEP, PAD, annotation, guess)
+                for left in (None, 'gone'):
+                    table[(left, None, symbols)] = f'ret {first} {last}'
+                    # the words to the right go first, this one after them
+                    for entered in states:
+                        table[(left, f'ret {entered} {first}', symbols)] = \
+                            f'ret {entered} {last}'
+
+        # a node both trees keep, below which words were dropped
+        for label, annotation in marks:
+            plain = (label, label, annotation, self.NONE)
+            for first in states:
+                for last in states:
+                    done = f'done {first} {last}'
+                    table[(f'ret {first} {last}', None, plain)] = done
+                    table[('same', f'ret {first} {last}', plain)] = done
+                    table[(None, f'ret {first} {last}', plain)] = done
+                    table[(done, None, plain)] = done
+                    table[('same', done, plain)] = done
+                    table[(None, done, plain)] = done
+
+        for source in states:
+            for target in states:
+                labels = (f'<{source}>', f'<{target}>', Annotation.START,
+                          self.NONE)
+                table[(f'done {source} {target}', None, labels)] = 'accept'
+                if source == target:
+                    table[('same', None, labels)] = 'accept'
+        return partial_tree_automaton(self.alphabet, 4, table, {'accept'})
+
+    def collapses_on_links(self) -> bool:
+        """Whether the system can collapse on a level 2 link at all — if it
+        cannot, `a_returns` is the whole of ``A``."""
+        pushes = {(rule.operation.symbol, rule.operation.level)
+                  for rule in self.system.rules
+                  if rule.operation.kind == 'push'}
+        if not any(level == 2 for _, level in pushes):
+            return False
+        return any(rule.operation.kind == 'collapse'
+                   for rule in self.system.rules)

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -716,11 +716,17 @@ class Relations:
         def chain(kind, label, first, final):
             return f'{kind}|{label}|{first}|{final}'
 
+        # Where the trees agree, carry up the annotation of the word the top
+        # path ends at. With no letter gained at all, C is a single high loop
+        # of that word — the run may touch where it started, which is what
+        # separates C from A and B — and this is where the root checks it.
+        agreed = [f'same {name}' for name in annotations]
         for label, annotation in marks:
-            for left in (None, 'same'):
-                for right in (None, 'same'):
+            for left in [None] + agreed:
+                for right in [None] + agreed:
+                    ends = right or left or f'same {annotation}'
                     table[(left, right, (label, label, annotation, self.NONE))] \
-                        = 'same'
+                        = ends
         # the separator the first tree carries, where its last word ends, and
         # the one the second loses
         table[(None, None, (SEP, PAD, PAD, self.NONE))] = 'added'
@@ -779,19 +785,22 @@ class Relations:
                                 source = chain(kind, below, final, deepest)
                                 target = f'{done} {start} {deepest}'
                                 table[(source, None, plain)] = target
-                                table[('same', source, plain)] = target
+                                for kept in agreed:
+                                    table[(kept, source, plain)] = target
                                 table[(None, source, plain)] = target
             for first in states:
                 for final in states:
                     for kind in ('done', 'cutdone'):
                         below_state = f'{kind} {first} {final}'
                         table[(below_state, None, plain)] = below_state
-                        table[('same', below_state, plain)] = below_state
+                        for kept in agreed:
+                            table[(kept, below_state, plain)] = below_state
                         table[(None, below_state, plain)] = below_state
                     grown = f'grown {first} {final}'
                     table[(f'cutdone {first} {final}', 'added', plain)] = grown
                     table[(grown, None, plain)] = grown
-                    table[('same', grown, plain)] = grown
+                    for kept in agreed:
+                        table[(kept, grown, plain)] = grown
                     table[(None, grown, plain)] = grown
 
         for source in states:
@@ -800,25 +809,34 @@ class Relations:
                           self.NONE)
                 for kind in ('done', 'grown'):
                     table[(f'{kind} {source} {target}', None, labels)] = 'accept'
-                if source == target:
-                    table[('same', None, labels)] = 'accept'
+                # no letter gained: one high loop of the topmost word
+                for name in annotations:
+                    summary = self.summary_of(name)
+                    if summary is not None and \
+                            (source, target) in summary.hloop:
+                        table[(f'same {name}', None, labels)] = 'accept'
         return partial_tree_automaton(self.alphabet, 4, table, {'accept'})
 
-    def a_returns(self) -> SparseTreeAutomaton:
-        """``A`` as far as returns take it: the stack loses whole words, one
-        return each.
+    def a(self) -> SparseTreeAutomaton:
+        """``A``: the stack loses whole words.
 
-        Kartzow's Lemma 4.11 decomposes a run of ``A`` into pieces that are
-        returns (F1), or a 1-loop followed by a level 2 collapse (F2), or a
-        1-loop followed by a pop that some later F2 closes off (F3). This
-        builds the F1 case. It is all of ``A`` for a system whose runs never
-        collapse on a level 2 link, since F2 and F3 both end in one; where they
-        can occur this under-approximates, and `collapses_on_links` says so.
+        Kartzow's Lemma 4.11 decomposes such a run into pieces that are
+        returns (F1), a 1-loop then a level 2 collapse (F2), or a 1-loop then a
+        pop that some later F2 closes off (F3). The words dropped are the
+        encoding's separators, and the run drops them from the last backwards
+        — so within a subtree the chain runs through the right child's
+        separators, then the left child's, then the node itself, which is
+        reverse traversal order.
 
-        The words the stack drops are the separators of the encoding, and the
-        run pops them from the last backwards — so within a subtree the chain
-        runs through the right child's separators, then the left child's, then
-        the node itself, which is reverse traversal order.
+        A collapse spans several words at once, which sounds like a link
+        reaching across the tree. It is not: a level 2 link records the number
+        of separators up to its letter, and the stack it points at is the
+        tree's prefix at that separator — which is exactly where the region
+        being deleted begins. So an F3-F2 group is a chain climbing the top
+        path *inside* that region, a 1-loop and a pop at each letter and a
+        1-loop and the collapse at the last, closed off by the region's own
+        root. Every check stays local, and the group then contributes a pair of
+        states to the outer chain just as a return does.
         """
         table = {}
         annotations = list(self.annotation.names.values())
@@ -855,6 +873,71 @@ class Relations:
                         table[(left, f'ret {entered} {first}', symbols)] = \
                             f'ret {entered} {last}'
 
+        # an F3*F2 group: the run climbs the region's top path, taking a
+        # letter off after each 1-loop, and collapses on the last of them
+        for label, annotation in marks:
+            if label not in self.encoding.letters:
+                continue
+            summary = self.summary_of(annotation)
+            symbol, _, level = label.rpartition(':')
+            for guess in self.guesses:
+                pair = self.guessed(guess)
+                if pair is None or summary is None:
+                    continue
+                first, last = pair
+                symbols = (label, PAD, annotation, guess)
+                # The 1-loop before each step may leave the stack as it was:
+                # a collapse straight off the top is no return -- it drops
+                # more than one word -- so nothing else would cover it.
+                idling = summary.oneloop | summary.loop
+                # ... a letter the group pops on its way up
+                if pair in compose(idling,
+                                   self.drop_moves(symbol, int(level))):
+                    for below in (None, 'gone'):
+                        table[(below, None, symbols)] = f'group {first} {last}'
+                    for start in states:
+                        # the node the chain came from is this one's left
+                        # child where the word goes on, and its right where a
+                        # separator ends the word -- the path takes either
+                        for other in (None, 'gone'):
+                            table[(f'group {start} {first}', other,
+                                   symbols)] = f'group {start} {last}'
+                            table[(other, f'group {start} {first}',
+                                   symbols)] = f'group {start} {last}'
+                # ... and the letter it collapses on, which ends the group
+                if int(level) == 2 and pair in compose(
+                        idling, self.summaries.moves(symbol, 'collapse')):
+                    for below in (None, 'gone'):
+                        table[(below, None, symbols)] = f'sprung {first} {last}'
+                        table[(None, below, symbols)] = f'sprung {first} {last}'
+                    for start in states:
+                        for other in (None, 'gone'):
+                            table[(f'group {start} {first}', other,
+                                   symbols)] = f'sprung {start} {last}'
+                            table[(other, f'group {start} {first}',
+                                   symbols)] = f'sprung {start} {last}'
+
+        # below the collapsed letter the region is dropped without any run
+        # step of its own, and the group closes at the region's root
+        for label, annotation in marks:
+            symbols = (label, PAD, annotation, self.NONE)
+            for first in states:
+                for last in states:
+                    sprung = f'sprung {first} {last}'
+                    if label in self.encoding.letters:
+                        for other in (None, 'gone'):
+                            table[(sprung, other, symbols)] = sprung
+                            table[(other, sprung, symbols)] = sprung
+                    else:                       # the region's root separator
+                        for other in (None, 'gone'):
+                            table[(sprung, other, symbols)] = \
+                                f'ret {first} {last}'
+                            table[(other, sprung, symbols)] = \
+                                f'ret {first} {last}'
+                        for entered in states:
+                            table[(sprung, f'ret {entered} {first}',
+                                   symbols)] = f'ret {entered} {last}'
+
         # a node both trees keep, below which words were dropped
         for label, annotation in marks:
             plain = (label, label, annotation, self.NONE)
@@ -878,8 +961,9 @@ class Relations:
         return partial_tree_automaton(self.alphabet, 4, table, {'accept'})
 
     def collapses_on_links(self) -> bool:
-        """Whether the system can collapse on a level 2 link at all — if it
-        cannot, `a_returns` is the whole of ``A``."""
+        """Whether the system can collapse on a level 2 link at all — the
+        case that makes `a` need its F2 and F3 pieces rather than returns
+        alone."""
         pushes = {(rule.operation.symbol, rule.operation.level)
                   for rule in self.system.rules
                   if rule.operation.kind == 'push'}

--- a/autstr/collapsible_reach.py
+++ b/autstr/collapsible_reach.py
@@ -160,7 +160,6 @@ class Summaries:
         self.converged = False
         self.values: Dict[tuple, Summary] = {}
         self.depth = depth
-        previous_bound = 0
         #: the words whose summary stopped growing when the bound last rose —
         #: a value can only grow, so agreeing twice means it is the truth
         self.stable: set = set()
@@ -169,15 +168,32 @@ class Summaries:
             self.depth = bound
             self.stable = {path for path in previous
                            if previous[path] == self.values[path]}
-            # the longest words of a round are the ones whose own extensions
-            # were pinned empty, so they always improve when the bound rises;
-            # convergence is about the words below that edge
-            if previous and all(
-                    previous[path] == self.values[path] for path in previous
-                    if len(path) < previous_bound):
-                self.converged = True
+            # Converged means the merged automaton is *closed*: every summary
+            # it can reach has a transition for every letter, all of them
+            # witnessed by words that have stopped growing. Anything less and
+            # a word the structure really contains may have no summary at all,
+            # which downstream shows up as a tree that cannot be annotated.
+            try:
+                start, table = self._merge()
+            except ValueError:
+                continue
+            reachable, frontier = {start}, [start]
+            while frontier:
+                current = frontier.pop()
+                for letter in self.letters:
+                    following = table.get((current, letter))
+                    if following is None:
+                        break
+                    if following not in reachable:
+                        reachable.add(following)
+                        frontier.append(following)
+                else:
+                    continue
                 break
-            previous_bound = bound
+            else:
+                self.converged = True
+                self._merged = (start, table)
+                break
 
     # -- the transitions available on one topmost symbol ----------------
     def _transitions(self, symbol: str) -> Dict[object, Relation]:
@@ -240,6 +256,16 @@ class Summaries:
 
     def transitions(self) -> Tuple[Summary, Dict[Tuple[Summary, Letter],
                                                  Summary]]:
+        """The merged automaton, as `_merge` builds it, once it is closed."""
+        if not self.converged:
+            raise ValueError(
+                f"the summaries were still growing, or the automaton they "
+                f"merge into is not closed, at {self.depth} letters; raise "
+                f"the limit")
+        return self._merged
+
+    def _merge(self) -> Tuple[Summary, Dict[Tuple[Summary, Letter],
+                                            Summary]]:
         """The summaries as an automaton: the summary of the bottom letter,
         and a table saying how one letter extends a summary.
 
@@ -248,11 +274,6 @@ class Summaries:
         fixpoint are left out of the merge: their own extensions were pinned
         empty, so what they say about a letter is not yet the truth.
         """
-        if not self.converged:
-            raise ValueError(
-                f"the summaries were still growing at {self.depth} letters, so "
-                f"words that look alike need not behave alike yet; raise the "
-                f"limit")
         # a word near the edge has its own extensions pinned empty, so what
         # it says about a letter is short of the truth; only the words whose
         # summary has stopped growing may speak
@@ -500,6 +521,10 @@ class Relations:
 
     #: a node no run visits, and so carries no guessed states
     NONE = '@-'
+    #: a node one collapse takes away along with everything around it — told
+    #: apart from an ordinary dropped letter on the tape, since the two inert
+    #: regions would otherwise want the same entry
+    BURIED = '@buried'
 
     def __init__(self, system: Level2CPS, summaries: Optional[Summaries] = None
                  ) -> None:
@@ -513,7 +538,16 @@ class Relations:
         self.guesses = [self.NONE] + [
             f'@{before},{after}' for before in system.states
             for after in system.states]
-        self.alphabet = set(self.annotation.alphabet) | set(self.guesses)
+        # D needs one thing more: whether the run ENDS in this subtree, passes
+        # through it, or is climbing out of what the two stacks share. A leaf
+        # can be any of the three, and a table has one entry per key, so the
+        # choice has to be on the tape rather than in the state.
+        self.guesses.append(self.BURIED)
+        self.walks = [f'&{before},{after},{kind}'
+                      for before in system.states for after in system.states
+                      for kind in ('end', 'thru', 'rise', 'start')]
+        self.alphabet = set(self.annotation.alphabet) | set(self.guesses) \
+            | set(self.walks)
 
     def summary_of(self, annotation: str) -> Optional[Summary]:
         """The summary an annotation letter stands for."""
@@ -532,10 +566,17 @@ class Relations:
 
     def guessed(self, guess: str) -> Optional[Tuple[str, str]]:
         """The pair of states a guess letter carries, or None."""
-        if guess == self.NONE:
+        if guess == self.NONE or guess.startswith('&'):
             return None
         before, _, after = guess[1:].partition(',')
         return before, after
+
+    def walked(self, guess: str) -> Optional[Tuple[str, str, str]]:
+        """The two states and the kind of walk a `D` guess letter carries."""
+        if not guess.startswith('&'):
+            return None
+        before, after, kind = guess[1:].split(',')
+        return before, after, kind
 
     def dropping(self, annotation: str, label: str, guess: str) -> bool:
         """Whether a letter may be dropped as the guess says: a high loop of
@@ -610,6 +651,37 @@ class Relations:
                 table[(None, f'chain {first} {last}', symbols)] = \
                     f'cutchain {first} {last}'
 
+        # A letter the run drops need not be one the second tree loses: when
+        # the word below shares it, the letter stays and only the separator
+        # moves up. So the chain carries on through nodes both trees keep,
+        # dropping their letters too.
+        for label, annotation in marks:
+            if label not in self.encoding.letters:
+                continue
+            for guess in self.guesses:
+                if not self.dropping(annotation, label, guess):
+                    continue
+                before, after = self.guessed(guess)
+                shared = (label, label, annotation, guess)
+                # the chain may even begin here, where the word loses only
+                # letters the word below it shares: then nothing is deleted
+                # but the separator that used to end it
+                # ... and the node it hangs from may carry it on either side:
+                # a letter's continuation is its left child, a separator its
+                # right
+                table[('cut', None, shared)] = f'cutrise {before} {after}'
+                table[(None, 'cut', shared)] = f'cutrise {before} {after}'
+                for start_state in self.system.states:
+                    # only once a separator has gone: a letter that stays may
+                    # be dropped exactly when the word below shares it, and
+                    # then the separator that ended the word moves up
+                    for kind in ('cutchain', 'cutrise'):
+                        for side in (None, 'same'):
+                            table[(f'{kind} {start_state} {before}', side,
+                                   shared)] = f'cutrise {start_state} {after}'
+                            table[(side, f'{kind} {start_state} {before}',
+                                   shared)] = f'cutrise {start_state} {after}'
+
         # the chain stops at a node both trees keep. From there up nothing may
         # follow it in either tree: coming from a right child anything already
         # read may sit to the left, but coming from a left child there must be
@@ -618,13 +690,15 @@ class Relations:
             plain = (label, label, annotation, self.NONE)
             for first, last in pairs:
                 for chain, kind in ((f'chain {first} {last}', 'done'),
-                                    (f'cutchain {first} {last}', 'cutdone')):
+                                    (f'cutchain {first} {last}', 'cutdone'),
+                                    (f'cutrise {first} {last}', 'cutdone')):
                     for below in (chain, f'{kind} {first} {last}'):
                         table[(below, None, plain)] = f'{kind} {first} {last}'
                         table[('same', below, plain)] = f'{kind} {first} {last}'
                         table[(None, below, plain)] = f'{kind} {first} {last}'
                 # the deleted separator is made good by the added one
                 for below in (f'cutchain {first} {last}',
+                              f'cutrise {first} {last}',
                               f'cutdone {first} {last}'):
                     table[(below, 'added', plain)] = f'grown {first} {last}'
                 grown = f'grown {first} {last}'
@@ -849,14 +923,25 @@ class Relations:
                 for right in (None, 'same'):
                     table[(left, right, (label, label, annotation, self.NONE))] \
                         = 'same'
-
-        # inside a word the first tree drops, nothing is guessed
+        # Inside a word the first tree drops, nothing is guessed -- but only
+        # its letters. A separator going means a whole word going, and every
+        # word that goes must be paid for by a return or by an F2 group's
+        # collapse; letting one pass as inert drops two words for the price of
+        # one.
         for label, annotation in marks:
+            if label not in self.encoding.letters:
+                continue
             for left in (None, 'gone'):
                 for right in (None, 'gone'):
                     table[(left, right, (label, PAD, annotation, self.NONE))] \
                         = 'gone'
-
+        # below the letter an F2 group collapses on, everything goes at once,
+        # separators included
+        for label, annotation in marks:
+            for left in (None, 'buried'):
+                for right in (None, 'buried'):
+                    table[(left, right,
+                           (label, PAD, annotation, self.BURIED))] = 'buried'
         # a separator the first tree drops: one return of the word it names
         for annotation in annotations:
             summary = self.summary_of(annotation)
@@ -893,13 +978,13 @@ class Relations:
                 # ... a letter the group pops on its way up
                 if pair in compose(idling,
                                    self.drop_moves(symbol, int(level))):
-                    for below in (None, 'gone'):
+                    for below in (None, 'buried'):
                         table[(below, None, symbols)] = f'group {first} {last}'
                     for start in states:
                         # the node the chain came from is this one's left
                         # child where the word goes on, and its right where a
                         # separator ends the word -- the path takes either
-                        for other in (None, 'gone'):
+                        for other in (None, 'buried'):
                             table[(f'group {start} {first}', other,
                                    symbols)] = f'group {start} {last}'
                             table[(other, f'group {start} {first}',
@@ -907,11 +992,11 @@ class Relations:
                 # ... and the letter it collapses on, which ends the group
                 if int(level) == 2 and pair in compose(
                         idling, self.summaries.moves(symbol, 'collapse')):
-                    for below in (None, 'gone'):
+                    for below in (None, 'buried'):
                         table[(below, None, symbols)] = f'sprung {first} {last}'
                         table[(None, below, symbols)] = f'sprung {first} {last}'
                     for start in states:
-                        for other in (None, 'gone'):
+                        for other in (None, 'buried'):
                             table[(f'group {start} {first}', other,
                                    symbols)] = f'sprung {start} {last}'
                             table[(other, f'group {start} {first}',
@@ -925,11 +1010,11 @@ class Relations:
                 for last in states:
                     sprung = f'sprung {first} {last}'
                     if label in self.encoding.letters:
-                        for other in (None, 'gone'):
+                        for other in (None, 'buried'):
                             table[(sprung, other, symbols)] = sprung
                             table[(other, sprung, symbols)] = sprung
                     else:                       # the region's root separator
-                        for other in (None, 'gone'):
+                        for other in (None, 'buried'):
                             table[(sprung, other, symbols)] = \
                                 f'ret {first} {last}'
                             table[(other, sprung, symbols)] = \
@@ -976,28 +1061,34 @@ class Relations:
         """``D``: the stack grows, and the run never dips below where it
         started.
 
-        Kartzow's Cor. 4.10 says such a run visits the milestones of the stack
-        it builds in order, consecutive ones joined by a single operation and a
-        loop — and the encoding puts those milestones in traversal order, one
-        per node. The run therefore only ever moves *forward* through the tree,
-        which is what decides where each operation goes: descending to a left
-        child is a push, and a new word is reached by cloning at the deepest
-        point of the word before it and then popping back up, one letter per
-        level, until the two words part company.
+        Kartzow's Cor. 4.10 walks the milestones of the stack being built,
+        consecutive ones joined by a single operation and a loop, and the
+        encoding lays them out one per node in traversal order. Measuring that
+        walk gives three moves and no others:
 
-        Cloning at the deepest point rather than where the words part is the
-        whole of it. The other way round would let a word be shorter than the
-        copy it came from for nothing, which is a run no system need have.
+            to a left child      push that letter
+            to a right child     clone
+            back up a level      pop, one per level, each node popping its own
+
+        with the clone that starts an ascent happening at the *deepest* node
+        reached, not where the two words part. A separator carries no letter,
+        so it pops nothing on the way out.
+
+        That makes one invariant per subtree: the run arrives at its root's
+        milestone in one state and leaves the subtree in another, having
+        cloned at its deepest node and popped back up to the word its parent
+        names. The run ends inside exactly one subtree, and there it leaves
+        by simply stopping — which is the difference between the two kinds of
+        walk state below.
         """
         table = {}
         annotations = list(self.annotation.names.values())
         marks = [(label, annotation)
                  for label in self.encoding.nodes for annotation in annotations]
-        letters = list(self.encoding.letters)
         states = self.system.states
 
-        def grew(cloned, label, arrive, leave):
-            return f'grew|{int(cloned)}|{label}|{arrive}|{leave}'
+        def walk(label, arrive, leave, kind):
+            return f'w|{label}|{arrive}|{leave}|{kind}'
 
         for label, annotation in marks:
             for left in (None, 'same'):
@@ -1011,82 +1102,136 @@ class Relations:
                 continue
             loop = summary.loop
             clones = self.summaries.moves(summary.symbol or '', 'clone')
-            for guess in self.guesses:
-                pair = self.guessed(guess)
-                if pair is None:
-                    continue
-                arrive, leave = pair
-                symbols = (PAD, label, annotation, guess)
+            # Leaving a subtree: clone down here, and then this node gives up
+            # its own letter -- unless it is a separator, which has none. The
+            # loop that follows that pop belongs to the word the PARENT names,
+            # not this one, so it is left for the parent to apply; each node
+            # loops on its own word before it pops.
+            if label in self.encoding.letters:
+                symbol, _, level = label.rpartition(':')
+                drop = self.drop_moves(symbol, int(level))
+                out = compose(compose(loop, clones), compose(loop, drop))
+                mine = compose(loop, drop)
+            else:
+                out = compose(loop, clones)
+                mine = loop
 
-                # the deepest milestone of a word: the run loops there, and
-                # clones if another word is still to come
-                if (arrive, leave) in loop:
-                    table[(None, None, symbols)] = \
-                        grew(False, label, arrive, leave)
-                if (arrive, leave) in compose(loop, clones):
-                    table[(None, None, symbols)] = \
-                        grew(True, label, arrive, leave)
+            for guess in self.walks:
+                arrive, leave, kind = self.walked(guess)
+                added = (PAD, label, annotation, guess)
+                shared = (label, label, annotation, guess)
 
-                for below in letters:
-                    symbol, _, level = below.rpartition(':')
+                # a milestone with nothing below it: the run either stops
+                # here, or clones and gives this node's letter back up
+                if kind == 'end' and (arrive, leave) in loop:
+                    table[(None, None, added)] = \
+                        walk(label, arrive, leave, 'end')
+                if kind == 'thru' and (arrive, leave) in out:
+                    table[(None, None, added)] = \
+                        walk(label, arrive, leave, 'thru')
+                if kind == 'rise' and (arrive, leave) in out:
+                    # the run starts at the top of the first stack and climbs
+                    # out of the part both trees share
+                    table[(None, None, shared)] = \
+                        walk(label, arrive, leave, 'rise')
+
+                for below in self.encoding.letters:
                     down = compose(loop, self.push_moves(annotation, below))
-                    up = compose(self.drop_moves(symbol, int(level)), loop)
                     for entered in states:
                         if (arrive, entered) not in down:
                             continue
                         for came_back in states:
-                            # deeper and never back: this word is the last
-                            child = grew(False, below, entered, came_back)
-                            if came_back == leave:
-                                table[(child, None, symbols)] = \
-                                    grew(False, label, arrive, leave)
-                            # deeper, cloned down there, and popping back up
-                            cloned = grew(True, below, entered, came_back)
-                            if (came_back, leave) in up:
-                                table[(cloned, None, symbols)] = \
-                                    grew(True, label, arrive, leave)
-                            # ... until the words part, where the new one
-                            # hangs as this node's right child
+                            child = walk(below, entered, came_back, 'thru')
+                            ends = walk(below, entered, came_back, 'end')
+                            # the run ends somewhere below
+                            if kind == 'end' and came_back == leave:
+                                table[(ends, None, added)] = \
+                                    walk(label, arrive, leave, 'end')
+                            # or comes back up and this node gives up its letter
+                            if kind == 'thru' and (came_back, leave) in mine:
+                                table[(child, None, added)] = \
+                                    walk(label, arrive, leave, 'thru')
+                            # or hands on to a word cloned from this one, which
+                            # the ascent has already popped down to
                             for last in states:
-                                sibling = grew(False, SEP, leave, last)
-                                if (came_back, leave) in up:
-                                    table[(cloned, sibling, symbols)] = \
-                                        grew(False, label, arrive, last)
-                                shared = grew(True, SEP, leave, last)
-                                if (came_back, leave) in up:
-                                    table[(cloned, shared, symbols)] = \
-                                        grew(True, label, arrive, last)
+                                for below_kind in ('end', 'thru'):
+                                    sibling = walk(SEP, came_back, last,
+                                                   below_kind)
+                                    if kind == 'end' and below_kind == 'end':
+                                        table[(child, sibling, added)] = \
+                                            walk(label, arrive, last, 'end')
+                                    elif kind == 'thru' and \
+                                            below_kind == 'thru' and \
+                                            (last, leave) in mine:
+                                        table[(child, sibling, added)] = \
+                                            walk(label, arrive, leave, 'thru')
 
-                # a word that parts from this one right here: the clone
-                # happened below, and nothing was popped since
-                for last in states:
-                    for kind in (False, True):
-                        sibling = grew(kind, SEP, leave, last)
-                        if (arrive, leave) in compose(loop, clones):
-                            table[(None, sibling, symbols)] = \
-                                grew(kind, label, arrive, last)
+                # a word cloned from this one, with nothing pushed first
+                across = compose(loop, clones)
+                for entered in states:
+                    if (arrive, entered) not in across:
+                        continue
+                    for last in states:
+                        for below_kind in ('end', 'thru'):
+                            sibling = walk(SEP, entered, last, below_kind)
+                            if kind == 'end' and below_kind == 'end':
+                                table[(None, sibling, added)] = \
+                                    walk(label, arrive, last, 'end')
+                            elif kind == 'thru' and below_kind == 'thru' and \
+                                    (last, leave) in mine:
+                                table[(None, sibling, added)] = \
+                                    walk(label, arrive, leave, 'thru')
 
-        # Where the growth hangs, and the run starts. The first new word is
-        # a clone of the one this node names, and this is the only place that
-        # clone can be checked -- inside the region every node is one the
-        # second tree alone has.
+        # climbing out of the shared part: each node gives up its own letter
+        # until the one the new words hang from
         for label, annotation in marks:
             summary = self.summary_of(annotation)
-            plain = (label, label, annotation, self.NONE)
             if summary is None:
                 continue
-            starts = compose(summary.loop,
-                             self.summaries.moves(summary.symbol or '', 'clone'))
-            for arrive in states:
-                for last in states:
-                    child = grew(False, SEP, arrive, last)
-                    for first in states:
-                        if (first, arrive) not in starts:
-                            continue
-                        done = f'done {first} {last}'
-                        for other in (None, 'same'):
-                            table[(other, child, plain)] = done
-                        table[(child, None, plain)] = done
+            plain = (label, label, annotation, self.NONE)
+            if label in self.encoding.letters:
+                symbol, _, level = label.rpartition(':')
+                mine = compose(summary.loop,
+                               self.drop_moves(symbol, int(level)))
+            else:
+                mine = summary.loop
+            # the state comes up from the child, so it is the CHILD's label
+            # the ascent has to name, not this node's
+            for child_label in self.encoding.nodes:
+                for first in states:
+                    for came_back in states:
+                        below = walk(child_label, first, came_back, 'rise')
+                        for leave in states:
+                            if (came_back, leave) not in mine:
+                                continue
+                            for other in (None, 'same'):
+                                table[(below, other, plain)] = \
+                                    walk(label, first, leave, 'rise')
+                        # where the new words hang: the ascent is over
+                        for last in states:
+                            sibling = walk(SEP, came_back, last, 'end')
+                            table[(below, sibling, plain)] = \
+                                f'done {first} {last}'
+
+            # Or the first stack ends right here, and the clone that starts
+            # the new words happens at this very node. Which state the run
+            # began in is a choice like any other, so it goes on the tape --
+            # two starts would otherwise want the same entry, and the table
+            # has room for one.
+            start = compose(summary.loop,
+                            self.summaries.moves(summary.symbol or '', 'clone'))
+            for entered in states:
+                for first in states:
+                    if (entered, first) not in start:
+                        continue
+                    marked = (label, label, annotation,
+                              f'&{entered},{first},start')
+                    for last in states:
+                        sibling = walk(SEP, first, last, 'end')
+                        # only where the shared part stops: a shared child
+                        # would mean the run began higher up than the first
+                        # stack actually reaches
+                        table[(None, sibling, marked)] = f'done {entered} {last}'
             for first in states:
                 for last in states:
                     done = f'done {first} {last}'

--- a/autstr/interpretations.py
+++ b/autstr/interpretations.py
@@ -231,20 +231,30 @@ def _tree_representatives(raw):
     choice this makes.
 
     The shadow itself never has to be computed. A description is a member `u`
-    for which *some* set of positions `n` is contained in every member of the
-    class and has `u` within ``|A_∼|`` levels of it; both halves grow with `n`,
-    so the existential quantifier settles on the shadow by itself, and the
-    hard half of the paper's argument — recognizing that a set of positions
-    *contains* the shadow — is never needed. What is left is one formula::
+    for which *some* set of positions `n` lies inside every member of the class
+    and holds `u` within ``|A_∼|`` levels of itself::
 
         u is a description of [t]  ≡  u ~ t ∧ ∃n. (∀s. t ~ s → dom(n) ⊆ dom(s))
                                                  ∧ dom(u) ⊆ dom(n)·{1,2}^{≤k}
 
-    read over a scratch presentation whose universe is *every* tree, since `n`
-    ranges over sets of positions rather than over elements. The exponential
-    blowup Kuske and Weidner prove unavoidable lives in that ``∀s`` — it is a
-    projection followed by a complement, and the subset construction inside it
-    is the ``2^Q`` of their Lemma 3.4.
+    The two conditions on `n` sandwich `u` rather than pulling against each
+    other. The first makes `n` a *lower* bound on the whole class, so — `u`
+    being a member — ``dom(n) ⊆ dom(u)`` already holds; the second is the
+    *upper* bound, and is what cuts an infinite class down to a finite set of
+    candidates, which is the whole point.
+
+    So the existential settles on the shadow by itself: the first condition
+    admits exactly the `n` below the shadow, and the second only gets weaker as
+    `n` grows, so the best `n` is the largest admissible one — the shadow. That
+    is why the hard half of the paper's argument, recognizing that a set of
+    positions *contains* the shadow, is never needed: nothing here ever asks
+    `n` to be at least the shadow.
+
+    The formula is read over a scratch presentation whose universe is *every*
+    tree, since `n` ranges over sets of positions rather than over elements.
+    The exponential blowup Kuske and Weidner prove unavoidable lives in that
+    ``∀s`` — it is a projection followed by a complement, and the subset
+    construction inside it is the ``2^Q`` of their Lemma 3.4.
 
     Expect the representatives themselves to be *large* trees, and much larger
     than the smallest member of their class: the order prefers a tree that

--- a/autstr/utils/tree_automata_tools.py
+++ b/autstr/utils/tree_automata_tools.py
@@ -48,7 +48,7 @@ from typing import Dict, FrozenSet, List, Optional, Set, Tuple
 
 import numpy as np
 
-from autstr.mtbdd import NONE, ComputedTable, bits_of, var_tables
+from autstr.mtbdd import NONE, ComputedTable, bits_of, num_bits, var_tables
 from autstr.sparse_tree_automata import SparseTreeAutomaton, Tree
 from autstr.utils.misc import encode_symbol
 
@@ -697,6 +697,43 @@ def iterate_trees(sta: SparseTreeAutomaton, max_entries: int = 10 ** 7):
                     for tree in trees]
         accepted.sort(key=_shortlex_key)
         yield from accepted
+
+
+def restrict_alphabet(sta: SparseTreeAutomaton, base_alphabet
+                      ) -> SparseTreeAutomaton:
+    """The same automaton, read over a smaller alphabet.
+
+    Every letter of `base_alphabet` must be one the automaton already has, and
+    the automaton keeps its behaviour on exactly those; what it did on the
+    letters being dropped simply goes away. That is what a construction wants
+    once a scaffolding letter has served its purpose — an annotation the
+    automaton was built to read and a projection has since quantified away
+    leaves the alphabet wider than the structure it belongs to.
+
+    The rewrite is one memoized pass over the diagrams: dropping letters
+    narrows the digit blocks rather than rebuilding any transition table.
+    """
+    old_letters = sorted(sta.base_alphabet_frozen)
+    new_letters = sorted(frozenset(base_alphabet))
+    index = {letter: position for position, letter in enumerate(old_letters)}
+    missing = [letter for letter in new_letters if letter not in index]
+    if missing:
+        raise ValueError(
+            f"the automaton has no letter {missing[0]!r}; an alphabet can only "
+            f"be restricted to letters it already reads")
+
+    source = [index[letter] for letter in new_letters]
+    new_m = len(new_letters)
+    new_bits = num_bits(new_m)
+    store = sta.store
+    nodes = [store.map_letters(int(node), sta.symbol_arity, sta.m, sta.bits,
+                               new_m, new_bits, source, sta.default_state)
+             for node in sta.pair_nodes.tolist()]
+    return SparseTreeAutomaton(
+        sta.num_states, sta.default_state,
+        is_accepting=sta.is_accepting, symbol_arity=sta.symbol_arity,
+        base_alphabet=set(new_letters),
+        pair_keys=sta.pair_keys, pair_nodes=np.array(nodes, dtype=np.int64))
 
 
 def partial_tree_automaton(base_alphabet, symbol_arity: int,

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -788,3 +788,93 @@ class TestRelationA:
                 configuration = Configuration(state, stack)
                 assert self.holds(relations, relation, configuration,
                                   configuration)
+
+
+def d_oracle(system, source, target, bound=3000):
+    """``D``: the stack grows, and after the first step nothing is a substack
+    of where it started."""
+    current = target.stack
+    grows = False
+    while current is not None:
+        if current == source.stack:
+            grows = True
+            break
+        current = current.pop2()
+    if not grows:
+        return False
+    if source.stack == target.stack:
+        return source == target
+    forbidden = set(substacks(source.stack))
+    seen, frontier, steps = {source}, deque([source]), 0
+    while frontier and steps < bound:
+        configuration = frontier.popleft()
+        steps += 1
+        for _, successor in system.step(configuration):
+            if successor.stack in forbidden:
+                continue
+            if successor == target:
+                return True
+            if successor in seen:
+                continue
+            if successor.stack.width > 4 or \
+                    max(map(len, successor.stack.words)) > 5:
+                continue
+            seen.add(successor)
+            frontier.append(successor)
+    return False
+
+
+class TestRelationD:
+    """``D`` — the stack grows. **Not correct yet.**
+
+    Kartzow's Cor. 4.10 walks the milestones of the stack being built, which
+    the encoding puts in traversal order. What this does not yet handle are
+    the *generalised* milestones: between one word and the next the run passes
+    through the previous word cloned whole, and only then pops it down to
+    where the two words part. Getting that wrong shows up in both directions,
+    and the two cases below are kept as a record of it.
+    """
+
+    CLONE_ONLY = [('0', None, 'c', '1', 'clone')]
+    NO_POPS = [('0', None, 'c', '1', 'clone'),
+               ('1', None, 'o', '0', 'pop 2')]
+
+    def relation(self, rules):
+        system = Level2CPS(rules, symbols=SYMBOLS)
+        relations = Relations(system)
+        return system, relations, relations.without_scaffolding(
+            relations.d(), annotated=1)
+
+    def holds(self, relations, relation, source, target):
+        return relation.accepts(convolve_trees(
+            [encode_configuration(source), encode_configuration(target)],
+            frozenset(relations.encoding.alphabet), PAD))
+
+    def test_one_clone(self):
+        system, relations, relation = self.relation(self.CLONE_ONLY)
+        for word in ((Letter('⊥'),), (Letter('⊥'), Letter('a'))):
+            assert self.holds(relations, relation,
+                              Configuration('0', Stack((word,))),
+                              Configuration('1', Stack((word, word))))
+
+    def test_it_is_reflexive(self):
+        system, relations, relation = self.relation(self.CLONE_ONLY)
+        for stack in walk_stacks(3, 6):
+            for state in system.states:
+                configuration = Configuration(state, stack)
+                assert self.holds(relations, relation, configuration,
+                                  configuration)
+
+    @pytest.mark.xfail(reason="the generalised milestones are not handled: "
+                              "the run clones the whole word before popping "
+                              "it down to where the two words part")
+    def test_a_word_shorter_than_its_clone_needs_pops(self):
+        """The system can only clone and pop words, never letters — so the
+        second word cannot be shorter than the first."""
+        system, relations, relation = self.relation(self.NO_POPS)
+        long_word = (Letter('⊥'), Letter('a'), Letter('a'))
+        short_word = (Letter('⊥'), Letter('a'))
+        assert not self.holds(
+            relations, relation,
+            Configuration('0', Stack((long_word,))),
+            Configuration('1', Stack((long_word, short_word))))

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -1,0 +1,227 @@
+"""Returns, loops and 1-loops of a level 2 collapsible pushdown system.
+
+Kartzow's reachability construction rests on a decomposition of every run into
+*returns* (a run from a stack to the one below it), *loops* (a run from a stack
+back to itself) and *1-loops*, and on the fact that which of these exist
+depends only on the stack's **topmost word**. This module's oracle is the
+definitions themselves, searched by hand: a bounded breadth-first walk over
+configurations that prunes whatever the definition forbids.
+
+Being bounded, the oracle is an under-approximation — what it finds really is
+there, and what it misses needs a longer run than the bound allows. That is the
+right direction for checking a construction that claims to find *everything*:
+every pair the oracle exhibits must appear in the computed set.
+"""
+from collections import deque
+
+from autstr.collapsible import Configuration, Letter, Level2CPS, Stack
+
+
+def zeroed(word):
+    """The word with every level 2 link set to 0 — Kartzow's ``w↓₀``.
+
+    Returns and loops are asked of a word rather than of a stack, and a link
+    into the stack below has no meaning once the stack is forgotten. Zeroing
+    them also makes those links unusable, which is exactly what the definition
+    of a return demands: it may not use the links stored in the topmost word.
+    """
+    return tuple(letter if letter.level == 1 else Letter(letter.symbol, 2, 0)
+                 for letter in word)
+
+
+def search(system, start, allowed, goal, bound=2000, size=6,
+           empty_run=False):
+    """The states in which `goal` is reached from `start`.
+
+    A breadth-first walk over configurations. `allowed` prunes the ones the
+    definition forbids as *intermediate* stacks — the goal is still recognized
+    when it is reached — and `size` caps the stacks so the walk terminates.
+
+    :param empty_run: whether the run of length zero counts, i.e. whether
+        `start` itself is reported when it already satisfies `goal`.
+    """
+    seen, frontier, reached = {start}, deque([start]), set()
+    if empty_run and goal(start):
+        reached.add(start.state)
+    steps = 0
+    while frontier and steps < bound:
+        configuration = frontier.popleft()
+        steps += 1
+        for _, successor in system.step(configuration):
+            if goal(successor):
+                reached.add(successor.state)
+            if successor in seen or not allowed(successor):
+                continue
+            stack = successor.stack
+            if stack.width > size or max(map(len, stack.words)) > size:
+                continue
+            seen.add(successor)
+            frontier.append(successor)
+    return reached
+
+
+def ex_ret(system, word):
+    """``ExRet(w)``: the pairs (q, q') with a return from ``(q, w:w)`` to
+    ``(q', w)``.
+
+    A return may not visit a substack of its target before the last step, and
+    every substack of the one-word stack ``w`` has width 1 — so the run must
+    stay at width 2 or more until it arrives.
+    """
+    word = zeroed(word)
+    target = Stack((word,))
+    return {(state, reached)
+            for state in system.states
+            for reached in search(
+                system, Configuration(state, Stack((word, word))),
+                allowed=lambda c: c.stack.width >= 2,
+                goal=lambda c: c.stack == target)}
+
+
+def ex_loop(system, word, kind='any'):
+    """``ExLoop(w)``, ``ExHLoop(w)``, ``ExLLoop(w)``: the pairs (q, q') with a
+    loop from ``(q, w)`` back to ``(q', w)``.
+
+    A loop may drop below its own topmost word only through letters carrying
+    level 1 links: reaching ``pop_1^k`` of the stack is allowed only when the k
+    letters it removed all had level 1 links. A *high* loop never drops at all;
+    a *low* loop drops on its first step and returns on its last.
+
+    The run of length zero is a loop, so ``ExLoop`` and ``ExHLoop`` contain
+    every ``(q, q)``; a low loop has to take its two steps, so ``ExLLoop`` need
+    not. That convention is what makes "one operation followed by some loop"
+    cover the bare operation as well.
+    """
+    word = zeroed(word)
+    stack = Stack((word,))
+    droppable = {word[:len(word) - k]
+                 for k in range(len(word) + 1)
+                 if all(letter.level == 1 for letter in word[len(word) - k:])}
+
+    def allowed(configuration):
+        current = configuration.stack
+        if current.width > 1:
+            return True                       # above the word: unconstrained
+        if kind == 'high' and current.words[0] != word:
+            return False                      # a high loop never drops
+        return current.words[0] in droppable or len(current.words[0]) > len(word)
+
+    pairs = set()
+    for state in system.states:
+        start = Configuration(state, stack)
+        if kind == 'low':
+            # a low loop steps down to pop_1(s) first and comes back last
+            below = stack.pop1()
+            if below is None:
+                continue
+            starts = [target for _, target in system.step(start)
+                      if target.stack == below]
+            reached = set()
+            for first in starts:
+                # the part between the two steps may itself be empty
+                for last in search(system, first, allowed,
+                                   goal=lambda c: c.stack == below,
+                                   empty_run=True):
+                    # ... and the final step climbs back onto the word
+                    reached |= {target.state for _, target
+                                in system.step(Configuration(last, below))
+                                if target.stack == stack}
+            pairs |= {(state, other) for other in reached}
+        else:
+            pairs |= {(state, other) for other in search(
+                system, start, allowed, goal=lambda c: c.stack == stack,
+                empty_run=True)}
+    return pairs
+
+
+def ex_one_loop(system, word):
+    """``ExOneLoop(w)``: the pairs (q, q') with a 1-loop from ``(q, w)`` to
+    ``(q', t:w)`` for some 2-word t — the stack grows underneath, and the
+    topmost word comes back exactly as it was."""
+    word = zeroed(word)
+    return {(state, reached)
+            for state in system.states
+            for reached in search(
+                system, Configuration(state, Stack((word,))),
+                allowed=lambda c: True,
+                goal=lambda c: c.stack.width > 1 and c.stack.words[-1] == word)}
+
+
+# ----------------------------------------------------------------------
+# the oracle against systems whose runs can be counted by hand
+# ----------------------------------------------------------------------
+
+BOTTOM = (Letter('⊥'),)
+
+
+class TestReturns:
+    def test_one_rule_that_pops(self):
+        """The only return is the single pop_2 step."""
+        system = Level2CPS([('p', None, 'o', 'q', 'pop 2')])
+        assert ex_ret(system, BOTTOM) == {('p', 'q')}
+
+    def test_cloning_alone_never_returns(self):
+        system = Level2CPS([('p', None, 'c', 'p', 'clone')])
+        assert ex_ret(system, BOTTOM) == set()
+
+    def test_a_collapse_of_a_freshly_pushed_letter_returns(self):
+        """Push a letter linked to the stack below, then collapse it: the
+        stack drops back by one word, which is a return."""
+        system = Level2CPS([('p', None, 'a', 'r', 'push a 2'),
+                            ('r', 'a', 'c', 'q', 'collapse')])
+        assert ex_ret(system, BOTTOM) == {('p', 'q')}
+
+    def test_a_return_may_take_a_detour_upwards(self):
+        """Clone first, pop twice: still a return, since the run never dips
+        below the target before the end. The two single pops are returns of
+        their own, from the states they start in."""
+        system = Level2CPS([('p', None, 'c', 'r', 'clone'),
+                            ('r', None, 'o', 's', 'pop 2'),
+                            ('s', None, 'o', 'q', 'pop 2')])
+        assert ex_ret(system, BOTTOM) == {('p', 'q'), ('r', 's'), ('s', 'q')}
+
+    def test_a_run_that_dips_below_the_target_is_no_return(self):
+        """Popping to width 1 and cloning back is not a return: it visits the
+        target's own substack on the way."""
+        system = Level2CPS([('p', None, 'o', 'r', 'pop 2'),
+                            ('r', None, 'c', 'q', 'clone')])
+        assert ('p', 'q') not in ex_ret(system, BOTTOM)
+        assert ex_ret(system, BOTTOM) == {('p', 'r')}
+
+
+class TestLoops:
+    def test_a_loop_that_never_leaves_the_word(self):
+        """Clone and pop back: a high loop, since it never drops a letter."""
+        system = Level2CPS([('p', None, 'c', 'r', 'clone'),
+                            ('r', None, 'o', 'q', 'pop 2')])
+        assert ('p', 'q') in ex_loop(system, BOTTOM)
+        assert ('p', 'q') in ex_loop(system, BOTTOM, kind='high')
+
+    def test_a_loop_that_drops_a_level_1_letter_and_writes_it_back(self):
+        word = (Letter('⊥'), Letter('a'))
+        system = Level2CPS([('p', 'a', 'o', 'r', 'pop 1'),
+                            ('r', None, 'w', 'q', 'push a 1')])
+        assert ('p', 'q') in ex_loop(system, word)
+        assert ('p', 'q') in ex_loop(system, word, kind='low')
+        assert ('p', 'q') not in ex_loop(system, word, kind='high')
+
+    def test_a_level_2_letter_may_not_be_dropped(self):
+        """The same run, but the letter carries a level 2 link — then passing
+        below it is not a loop at all."""
+        word = (Letter('⊥'), Letter('a', 2, 0))
+        system = Level2CPS([('p', 'a', 'o', 'r', 'pop 1'),
+                            ('r', None, 'w', 'q', 'push a 2')])
+        assert ('p', 'q') not in ex_loop(system, word)
+        assert ex_loop(system, word) == {(q, q) for q in system.states}
+
+
+class TestOneLoops:
+    def test_the_stack_grows_underneath(self):
+        """Clone: the topmost word is back where it started, with a copy of
+        itself underneath."""
+        system = Level2CPS([('p', None, 'c', 'q', 'clone')])
+        assert ('p', 'q') in ex_one_loop(system, BOTTOM)
+
+    def test_popping_is_no_one_loop(self):
+        system = Level2CPS([('p', None, 'o', 'q', 'pop 2')])
+        assert ex_one_loop(system, BOTTOM) == set()

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -18,10 +18,10 @@ from collections import deque
 import pytest
 
 from autstr.collapsible import (
-    Configuration, Letter, Level2CPS, PAD, Stack, _Encoding,
-    encode_configuration,
+    Configuration, Letter, Level2CPS, Operation, PAD, Stack, _Encoding,
+    encode_configuration, initial_stack,
 )
-from autstr.collapsible_reach import Annotation, Summaries
+from autstr.collapsible_reach import Annotation, Relations, Summaries
 from autstr.sparse_tree_automata import Tree, convolve_trees
 
 
@@ -447,3 +447,124 @@ class TestAnnotation:
         first, table = Summaries(system, depth=4, limit=6).transitions()
         assert first.symbol == '⊥'
         assert all(isinstance(key[1], tuple) for key in table)
+
+
+# ----------------------------------------------------------------------
+# the relations reachability decomposes into
+# ----------------------------------------------------------------------
+
+def substacks(stack):
+    """Every substack: pop the words, then the letters."""
+    out, current = [], stack
+    while current is not None:
+        inner = current
+        while inner is not None:
+            out.append(inner)
+            inner = inner.pop1()
+        current = current.pop2()
+    return out
+
+
+def drops_to(source, target):
+    """Is the target the source with letters taken off its topmost word?"""
+    current = source
+    while current is not None:
+        if current == target:
+            return True
+        current = current.pop1()
+    return False
+
+
+def b_oracle(system, source, target, bound=3000):
+    """``B``: a run to a shorter topmost word that never dips below it."""
+    if not drops_to(source.stack, target.stack):
+        return False
+    if source == target:
+        return True                             # the run of no steps
+    forbidden = set(substacks(target.stack))
+    seen, frontier, steps = {source}, deque([source]), 0
+    while frontier and steps < bound:
+        configuration = frontier.popleft()
+        steps += 1
+        for _, successor in system.step(configuration):
+            if successor == target:
+                return True
+            if successor in seen or successor.stack in forbidden:
+                continue
+            if successor.stack.width > 4 or \
+                    max(map(len, successor.stack.words)) > 6:
+                continue
+            seen.add(successor)
+            frontier.append(successor)
+    return False
+
+
+def walk_stacks(seed, count, width=3, height=4):
+    """Stacks from a random walk, kept small enough to search exhaustively."""
+    rng, stack, out = random.Random(seed), initial_stack(), []
+    operations = ([Operation('clone')]
+                  + [Operation('push', symbol, level)
+                     for symbol in SYMBOLS for level in (1, 2)]
+                  + [Operation('pop', level=1), Operation('pop', level=2)])
+    while len(out) < count:
+        stack = stack.apply(rng.choice(operations)) or initial_stack()
+        if stack.width <= width and max(map(len, stack.words)) <= height:
+            out.append(stack)
+    return out
+
+
+class TestRelationB:
+    """``B`` — the topmost word loses letters, and the run never dips below
+    what is left. The two trees then differ along a tail of the first one's
+    last path, and the second may gain the one separator the first loses."""
+
+    CASES = {
+        'pop and push back': [('0', None, 'p', '1', 'pop 1'),
+                              ('1', None, 'u', '0', 'push a 1')],
+        'a loop before each pop': [('0', None, 'c', '1', 'clone'),
+                                   ('1', None, 'o', '0', 'pop 2'),
+                                   ('0', 'a', 'p', '2', 'pop 1'),
+                                   ('2', None, 'u', '0', 'push b 1')],
+    }
+
+    def relation(self, rules):
+        system = Level2CPS(rules, symbols=SYMBOLS)
+        relations = Relations(system)
+        return system, relations, relations.without_scaffolding(relations.b())
+
+    def holds(self, relations, relation, source, target):
+        return relation.accepts(convolve_trees(
+            [encode_configuration(source), encode_configuration(target)],
+            frozenset(relations.encoding.alphabet), PAD))
+
+    @pytest.mark.parametrize("case", sorted(CASES))
+    def test_against_the_search(self, case):
+        system, relations, relation = self.relation(self.CASES[case])
+        configurations = [Configuration(state, stack)
+                          for stack in walk_stacks(7, 8)
+                          for state in system.states]
+        for source in configurations:
+            for target in configurations:
+                assert self.holds(relations, relation, source, target) == \
+                    b_oracle(system, source, target), (source, target)
+
+    def test_it_is_reflexive(self):
+        """Every configuration reaches itself by the run of no steps, so the
+        two trees are simply equal."""
+        system, relations, relation = self.relation(
+            self.CASES['pop and push back'])
+        for stack in walk_stacks(3, 6):
+            for state in system.states:
+                configuration = Configuration(state, stack)
+                assert self.holds(relations, relation, configuration,
+                                  configuration)
+
+    def test_dropping_a_word_is_not_dropping_letters(self):
+        """A pair whose widths differ is refused whatever the runs do: B moves
+        within the topmost word."""
+        system, relations, relation = self.relation(
+            self.CASES['pop and push back'])
+        tall = Stack(((Letter('⊥'), Letter('a')), (Letter('⊥'), Letter('a'))))
+        assert not self.holds(relations, relation,
+                              Configuration('0', tall),
+                              Configuration('0', Stack((tall.words[0],))))

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -656,3 +656,111 @@ class TestRelationC:
         assert self.holds(relations, relation,
                           Configuration('0', twice),
                           Configuration('1', longer))
+
+
+def pops_words_to(source, target):
+    """Is the target the source with whole words taken off?"""
+    current = source
+    while current is not None:
+        if current == target:
+            return True
+        current = current.pop2()
+    return False
+
+
+def a_oracle(system, source, target, bound=3000):
+    """``A``: a run that drops whole words and never dips below the target."""
+    if not pops_words_to(source.stack, target.stack):
+        return False
+    if source == target:
+        return True
+    forbidden = set(substacks(target.stack))
+    seen, frontier, steps = {source}, deque([source]), 0
+    while frontier and steps < bound:
+        configuration = frontier.popleft()
+        steps += 1
+        for _, successor in system.step(configuration):
+            if successor == target:
+                return True
+            if successor in seen or successor.stack in forbidden:
+                continue
+            if successor.stack.width > 4 or \
+                    max(map(len, successor.stack.words)) > 5:
+                continue
+            seen.add(successor)
+            frontier.append(successor)
+    return False
+
+
+class TestRelationAFromReturns:
+    """``A`` as far as returns take it.
+
+    Kartzow's decomposition allows three kinds of piece: a return, a 1-loop
+    then a level 2 collapse, and a 1-loop then a pop that a later collapse
+    closes off. Only the first is built here, which is all of ``A`` unless a
+    collapse drops *several* words at once — a single word's worth is already
+    inside a return, since the summaries count a pushed link collapsed after a
+    1-loop as one.
+    """
+
+    EXACT = {
+        'clone and pop': [('0', None, 'c', '1', 'clone'),
+                          ('1', None, 'o', '0', 'pop 2')],
+        'a loop before each pop': [('0', None, 'u', '1', 'push a 1'),
+                                   ('1', 'a', 'p', '0', 'pop 1'),
+                                   ('0', None, 'o', '0', 'pop 2')],
+        'a collapse over one word': [('0', None, 'u', '1', 'push a 2'),
+                                     ('1', 'a', 'x', '2', 'collapse')],
+    }
+    #: a collapse that drops every word the clones added — F2 and F3 territory
+    INCOMPLETE = [('0', None, 'c', '0', 'clone'),
+                  ('0', None, 'u', '1', 'push a 2'),
+                  ('1', None, 'k', '1', 'clone'),
+                  ('1', 'a', 'x', '2', 'collapse')]
+
+    def relation(self, rules):
+        system = Level2CPS(rules, symbols=SYMBOLS)
+        relations = Relations(system)
+        return system, relations, relations.without_scaffolding(
+            relations.a_returns())
+
+    def holds(self, relations, relation, source, target):
+        return relation.accepts(convolve_trees(
+            [encode_configuration(source), encode_configuration(target)],
+            frozenset(relations.encoding.alphabet), PAD))
+
+    @pytest.mark.parametrize("case", sorted(EXACT))
+    def test_it_is_exact_where_no_collapse_spans_words(self, case):
+        system, relations, relation = self.relation(self.EXACT[case])
+        configurations = [Configuration(state, stack)
+                          for stack in walk_stacks(5, 8, width=3, height=3)
+                          for state in system.states]
+        for source in configurations:
+            for target in configurations:
+                assert self.holds(relations, relation, source, target) == \
+                    a_oracle(system, source, target), (source, target)
+
+    def test_it_is_sound_where_it_is_not_complete(self):
+        """Where a collapse spans several words the runs are missed, but none
+        are invented — the relation stays inside the truth."""
+        system, relations, relation = self.relation(self.INCOMPLETE)
+        assert relations.collapses_on_links()
+        configurations = [Configuration(state, stack)
+                          for stack in walk_stacks(5, 8, width=3, height=3)
+                          for state in system.states]
+        missed = 0
+        for source in configurations:
+            for target in configurations:
+                got = self.holds(relations, relation, source, target)
+                want = a_oracle(system, source, target)
+                assert not (got and not want), (source, target)
+                missed += want and not got
+        assert missed, "this system is meant to show the gap"
+
+    def test_it_is_reflexive(self):
+        system, relations, relation = self.relation(self.EXACT['clone and pop'])
+        for stack in walk_stacks(3, 6):
+            for state in system.states:
+                configuration = Configuration(state, stack)
+                assert self.holds(relations, relation, configuration,
+                                  configuration)

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -17,8 +17,12 @@ from collections import deque
 
 import pytest
 
-from autstr.collapsible import Configuration, Letter, Level2CPS, Stack
-from autstr.collapsible_reach import Summaries
+from autstr.collapsible import (
+    Configuration, Letter, Level2CPS, PAD, Stack, _Encoding,
+    encode_configuration,
+)
+from autstr.collapsible_reach import Annotation, Summaries
+from autstr.sparse_tree_automata import Tree, convolve_trees
 
 
 def zeroed(word):
@@ -364,3 +368,82 @@ class TestSummaries:
     def test_summaries_have_a_readable_repr(self):
         system = Level2CPS(self.CASES['a single pop'], symbols=SYMBOLS)
         assert 'Summaries' in repr(Summaries(system, depth=2, limit=2))
+
+
+class TestAnnotation:
+    """The summary annotation tape: a node carries the summary of the word
+    read from the root down to it, and the automaton checks that locally."""
+
+    @pytest.fixture(scope="class")
+    def setup(self):
+        system = Level2CPS([('0', None, 'Cl', '1', 'clone'),
+                            ('1', None, 'A', '0', 'push a 2'),
+                            ('1', None, 'B', '2', 'push a 1'),
+                            ('2', 'a', 'P', '2', 'pop 1'),
+                            ('2', 'a', 'Co', '0', 'collapse')])
+        encoding = _Encoding(system.states, system.symbols, system.bottom)
+        annotation = Annotation(encoding, Summaries(system, depth=4, limit=6))
+        return system, annotation, annotation.automaton()
+
+    def convolution(self, annotation, tree, marks):
+        return convolve_trees([tree, marks], frozenset(annotation.alphabet),
+                              PAD)
+
+    def test_the_right_annotation_is_accepted(self, setup):
+        system, annotation, automaton = setup
+        for configuration in system.reachable(bound=6):
+            tree = encode_configuration(configuration)
+            marks = annotation.of_tree(tree)
+            assert automaton.accepts(
+                self.convolution(annotation, tree, marks)), configuration
+
+    def test_the_annotation_follows_the_word_down_the_tree(self, setup):
+        _, annotation, _ = setup
+        # the root reads no letter; below it the annotations follow the
+        # summaries of ⊥, ⊥a, ... and a separator repeats its parent's
+        tree = encode_configuration(Configuration(
+            '0', Stack(((Letter('⊥'), Letter('a', 2, 0)),
+                        (Letter('⊥'),)))))
+        marks = annotation.of_tree(tree)
+        assert marks.label == Annotation.START
+        assert marks.left.label == annotation.first
+        assert marks.left.right.label == marks.left.label   # a separator
+
+    def test_a_wrong_annotation_is_rejected(self, setup):
+        system, annotation, automaton = setup
+        others = [letter for letter in annotation.letters
+                  if letter != Annotation.START]
+        for configuration in system.reachable(bound=5):
+            tree = encode_configuration(configuration)
+            marks = annotation.of_tree(tree)
+            if marks.left is None:
+                continue
+            for wrong in others:
+                if wrong == marks.left.label:
+                    continue
+                spoiled = Tree(marks.label,
+                               Tree(wrong, marks.left.left, marks.left.right),
+                               marks.right)
+                assert not automaton.accepts(
+                    self.convolution(annotation, tree, spoiled))
+
+    def test_an_annotation_of_the_wrong_shape_is_rejected(self, setup):
+        system, annotation, automaton = setup
+        configuration = system.reachable(bound=4)[-1]
+        tree = encode_configuration(configuration)
+        marks = annotation.of_tree(tree)
+        # one node short, and one node too many
+        assert not automaton.accepts(
+            self.convolution(annotation, tree, Tree(marks.label)))
+        assert not automaton.accepts(self.convolution(
+            annotation, tree,
+            Tree(marks.label, marks.left, Tree(annotation.first))))
+
+    def test_summaries_merge_into_an_automaton(self):
+        """Words that behave alike are one state — and while the fixpoint is
+        still moving, the merge is refused rather than guessed at."""
+        system = Level2CPS([('0', None, 'c', '0', 'clone'),
+                            ('0', None, 'p', '0', 'push a 2')])
+        first, table = Summaries(system, depth=4, limit=6).transitions()
+        assert first.symbol == '⊥'
+        assert all(isinstance(key[1], tuple) for key in table)

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -476,11 +476,14 @@ def drops_to(source, target):
 
 
 def b_oracle(system, source, target, bound=3000):
-    """``B``: a run to a shorter topmost word that never dips below it."""
+    """``B``: a run to a shorter topmost word that never dips below it.
+
+    As with ``A``, dropping no letter at all leaves only the empty run.
+    """
     if not drops_to(source.stack, target.stack):
         return False
-    if source == target:
-        return True                             # the run of no steps
+    if source.stack == target.stack:
+        return source == target
     forbidden = set(substacks(target.stack))
     seen, frontier, steps = {source}, deque([source]), 0
     while frontier and steps < bound:
@@ -669,11 +672,17 @@ def pops_words_to(source, target):
 
 
 def a_oracle(system, source, target, bound=3000):
-    """``A``: a run that drops whole words and never dips below the target."""
+    """``A``: a run that drops whole words and never dips below the target.
+
+    With no word dropped at all the condition already fails at the run's first
+    step — the stack it starts on *is* a substack of the target — so nothing
+    but the empty run qualifies. A loop that stays where it is belongs to C,
+    whose condition excludes only the *proper* substacks.
+    """
     if not pops_words_to(source.stack, target.stack):
         return False
-    if source == target:
-        return True
+    if source.stack == target.stack:
+        return source == target
     forbidden = set(substacks(target.stack))
     seen, frontier, steps = {source}, deque([source]), 0
     while frontier and steps < bound:
@@ -692,15 +701,16 @@ def a_oracle(system, source, target, bound=3000):
     return False
 
 
-class TestRelationAFromReturns:
-    """``A`` as far as returns take it.
+class TestRelationA:
+    """``A`` — the stack loses whole words.
 
     Kartzow's decomposition allows three kinds of piece: a return, a 1-loop
     then a level 2 collapse, and a 1-loop then a pop that a later collapse
-    closes off. Only the first is built here, which is all of ``A`` unless a
-    collapse drops *several* words at once — a single word's worth is already
-    inside a return, since the summaries count a pushed link collapsed after a
-    1-loop as one.
+    closes off. A collapse spanning several words looks like a link reaching
+    across the tree, but a level 2 link records the number of separators up to
+    its letter, and the stack it points at is the tree's prefix at that
+    separator — exactly where the deleted region begins. So the group is a
+    chain climbing that region's own top path.
     """
 
     EXACT = {
@@ -712,17 +722,17 @@ class TestRelationAFromReturns:
         'a collapse over one word': [('0', None, 'u', '1', 'push a 2'),
                                      ('1', 'a', 'x', '2', 'collapse')],
     }
-    #: a collapse that drops every word the clones added — F2 and F3 territory
-    INCOMPLETE = [('0', None, 'c', '0', 'clone'),
-                  ('0', None, 'u', '1', 'push a 2'),
-                  ('1', None, 'k', '1', 'clone'),
-                  ('1', 'a', 'x', '2', 'collapse')]
+    #: a collapse that drops every word the clones added
+    SPANNING = [('0', None, 'c', '0', 'clone'),
+                ('0', None, 'u', '1', 'push a 2'),
+                ('1', None, 'k', '1', 'clone'),
+                ('1', 'a', 'x', '2', 'collapse')]
 
     def relation(self, rules):
         system = Level2CPS(rules, symbols=SYMBOLS)
         relations = Relations(system)
         return system, relations, relations.without_scaffolding(
-            relations.a_returns())
+            relations.a())
 
     def holds(self, relations, relation, source, target):
         return relation.accepts(convolve_trees(
@@ -730,7 +740,7 @@ class TestRelationAFromReturns:
             frozenset(relations.encoding.alphabet), PAD))
 
     @pytest.mark.parametrize("case", sorted(EXACT))
-    def test_it_is_exact_where_no_collapse_spans_words(self, case):
+    def test_against_the_search(self, case):
         system, relations, relation = self.relation(self.EXACT[case])
         configurations = [Configuration(state, stack)
                           for stack in walk_stacks(5, 8, width=3, height=3)
@@ -740,22 +750,36 @@ class TestRelationAFromReturns:
                 assert self.holds(relations, relation, source, target) == \
                     a_oracle(system, source, target), (source, target)
 
-    def test_it_is_sound_where_it_is_not_complete(self):
-        """Where a collapse spans several words the runs are missed, but none
-        are invented — the relation stays inside the truth."""
-        system, relations, relation = self.relation(self.INCOMPLETE)
+    def test_a_collapse_that_spans_several_words(self):
+        system, relations, relation = self.relation(self.SPANNING)
         assert relations.collapses_on_links()
         configurations = [Configuration(state, stack)
                           for stack in walk_stacks(5, 8, width=3, height=3)
                           for state in system.states]
-        missed = 0
         for source in configurations:
             for target in configurations:
-                got = self.holds(relations, relation, source, target)
-                want = a_oracle(system, source, target)
-                assert not (got and not want), (source, target)
-                missed += want and not got
-        assert missed, "this system is meant to show the gap"
+                assert self.holds(relations, relation, source, target) == \
+                    a_oracle(system, source, target), (source, target)
+
+    def test_a_collapse_no_sequence_of_returns_could_make(self):
+        """The only rule is a collapse, so the system has no return at all —
+        and the stack still drops two words in one step, which nothing but the
+        1-loop-and-collapse piece can account for."""
+        system = Level2CPS([('p', 'a', 'x', 'q', 'collapse')], symbols=SYMBOLS)
+        relations = Relations(system)
+        relation = relations.without_scaffolding(relations.a())
+        assert all(not summary.ret
+                   for summary in relations.summaries.values.values())
+
+        word = (Letter('⊥'), Letter('a', 2, 1))
+        tall = Stack(((Letter('⊥'),), word, word))
+        short = Stack(((Letter('⊥'),),))
+        assert tall.collapse() == short          # two words in one step
+        assert self.holds(relations, relation, Configuration('p', tall),
+                          Configuration('q', short))
+        # and only from the state the collapse fires in
+        assert not self.holds(relations, relation, Configuration('q', tall),
+                              Configuration('q', short))
 
     def test_it_is_reflexive(self):
         system, relations, relation = self.relation(self.EXACT['clone and pop'])

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -12,9 +12,13 @@ there, and what it misses needs a longer run than the bound allows. That is the
 right direction for checking a construction that claims to find *everything*:
 every pair the oracle exhibits must appear in the computed set.
 """
+import random
 from collections import deque
 
+import pytest
+
 from autstr.collapsible import Configuration, Letter, Level2CPS, Stack
+from autstr.collapsible_reach import Summaries
 
 
 def zeroed(word):
@@ -94,56 +98,68 @@ def ex_loop(system, word, kind='any'):
     """
     word = zeroed(word)
     stack = Stack((word,))
-    droppable = {word[:len(word) - k]
-                 for k in range(len(word) + 1)
-                 if all(letter.level == 1 for letter in word[len(word) - k:])}
 
-    def allowed(configuration):
-        current = configuration.stack
-        if current.width > 1:
-            return True                       # above the word: unconstrained
-        if kind == 'high' and current.words[0] != word:
-            return False                      # a high loop never drops
-        return current.words[0] in droppable or len(current.words[0]) > len(word)
+    def staying(base, high):
+        """A loop of `base` may push and pop above it freely; what it may not
+        do is drop below, except through letters carrying level 1 links — and
+        a high loop may not drop at all."""
+        def allowed(configuration):
+            current = configuration.stack
+            if current.width > 1:
+                return True                   # above the word: unconstrained
+            here = current.words[0]
+            if len(here) >= len(base):
+                return True                   # the word itself, or longer
+            return not high and all(letter.level == 1
+                                    for letter in base[len(here):])
+        return allowed
 
-    pairs = set()
-    for state in system.states:
-        start = Configuration(state, stack)
-        if kind == 'low':
-            # a low loop steps down to pop_1(s) first and comes back last
-            below = stack.pop1()
-            if below is None:
-                continue
-            starts = [target for _, target in system.step(start)
-                      if target.stack == below]
-            reached = set()
-            for first in starts:
-                # the part between the two steps may itself be empty
-                for last in search(system, first, allowed,
+    if kind == 'low':
+        # a low loop steps down to pop_1(s), loops there, and writes the
+        # letter back — so the letter has to be one that may be dropped
+        below = stack.pop1()
+        if below is None or word[-1].level != 1:
+            return set()
+        pairs = set()
+        for state in system.states:
+            for _, first in system.step(Configuration(state, stack)):
+                if first.stack != below:
+                    continue
+                # the part between the two steps is a loop of the word below,
+                # and may itself be empty
+                for last in search(system, first,
+                                   staying(below.words[0], False),
                                    goal=lambda c: c.stack == below,
                                    empty_run=True):
-                    # ... and the final step climbs back onto the word
-                    reached |= {target.state for _, target
-                                in system.step(Configuration(last, below))
-                                if target.stack == stack}
-            pairs |= {(state, other) for other in reached}
-        else:
-            pairs |= {(state, other) for other in search(
-                system, start, allowed, goal=lambda c: c.stack == stack,
-                empty_run=True)}
-    return pairs
+                    pairs |= {(state, target.state) for _, target
+                              in system.step(Configuration(last, below))
+                              if target.stack == stack}
+        return pairs
+
+    allowed = staying(word, kind == 'high')
+    return {(state, other)
+            for state in system.states
+            for other in search(system, Configuration(state, stack), allowed,
+                                goal=lambda c: c.stack == stack,
+                                empty_run=True)}
 
 
 def ex_one_loop(system, word):
     """``ExOneLoop(w)``: the pairs (q, q') with a 1-loop from ``(q, w)`` to
-    ``(q', t:w)`` for some 2-word t — the stack grows underneath, and the
-    topmost word comes back exactly as it was."""
+    ``(q', t:w)`` for some *stack* t — the stack grows underneath, and the
+    topmost word comes back exactly as it was.
+
+    The definition also asks that wherever the run shortens the topmost word
+    it later returns; rather than track that, this forbids shortening it at
+    all, which is a run of the required shape either way. So this direction
+    under-approximates more than the search bound alone does.
+    """
     word = zeroed(word)
     return {(state, reached)
             for state in system.states
             for reached in search(
                 system, Configuration(state, Stack((word,))),
-                allowed=lambda c: True,
+                allowed=lambda c: len(c.stack.words[-1]) >= len(word),
                 goal=lambda c: c.stack.width > 1 and c.stack.words[-1] == word)}
 
 
@@ -225,3 +241,126 @@ class TestOneLoops:
     def test_popping_is_no_one_loop(self):
         system = Level2CPS([('p', None, 'o', 'q', 'pop 2')])
         assert ex_one_loop(system, BOTTOM) == set()
+
+
+# ----------------------------------------------------------------------
+# the computed summaries, against that oracle
+# ----------------------------------------------------------------------
+
+SYMBOLS = ('a', 'b')
+OPERATIONS = ['clone', 'pop 1', 'pop 2', 'collapse',
+              'push a 1', 'push a 2', 'push b 1', 'push b 2']
+
+#: words to compare on, from the bare bottom letter to one of every kind
+SAMPLE_WORDS = [
+    (Letter('⊥'),),
+    (Letter('⊥'), Letter('a')),
+    (Letter('⊥'), Letter('a', 2, 0)),
+    (Letter('⊥'), Letter('b'), Letter('a', 2, 0)),
+]
+
+
+def as_path(word):
+    return [(letter.symbol, letter.level) for letter in word]
+
+
+def oracle(system, word):
+    """Every set the oracle can find, as the computed summary spells them."""
+    return {'ret': ex_ret(system, word),
+            'hloop': ex_loop(system, word, kind='high'),
+            'lloop': ex_loop(system, word, kind='low'),
+            'loop': ex_loop(system, word),
+            'oneloop': ex_one_loop(system, word)}
+
+
+def computed(summaries, word):
+    summary = summaries.of_word(as_path(word))
+    return {'ret': summary.ret, 'hloop': summary.hloop,
+            'lloop': summary.lloop, 'loop': summary.loop,
+            'oneloop': summary.oneloop}
+
+
+def random_system(rng):
+    states = [str(index) for index in range(rng.randint(1, 3))]
+    return Level2CPS([(rng.choice(states),
+                       rng.choice([None] + list(SYMBOLS) + ['⊥']),
+                       f'g{index}', rng.choice(states),
+                       rng.choice(OPERATIONS))
+                      for index in range(rng.randint(1, 6))],
+                     symbols=SYMBOLS)
+
+
+class TestSummaries:
+    """The computed summaries against the searched ones.
+
+    The oracle under-approximates — its search is bounded, and it will not
+    chase the side condition on 1-loops — so what it finds must always appear
+    in the computed summary. On the small systems here the two agree exactly.
+    """
+
+    CASES = {
+        'a single pop': [('p', None, 'o', 'q', 'pop 2')],
+        'cloning only': [('p', None, 'c', 'p', 'clone')],
+        'push then collapse': [('p', None, 'a', 'r', 'push a 2'),
+                               ('r', 'a', 'c', 'q', 'collapse')],
+        'clone then two pops': [('p', None, 'c', 'r', 'clone'),
+                                ('r', None, 'o', 's', 'pop 2'),
+                                ('s', None, 'o', 'q', 'pop 2')],
+        'drop and rewrite': [('p', 'a', 'o', 'r', 'pop 1'),
+                             ('r', None, 'w', 'q', 'push a 1')],
+        'clone and pop back': [('p', None, 'c', 'r', 'clone'),
+                               ('r', None, 'o', 'q', 'pop 2')],
+    }
+
+    @pytest.mark.parametrize("case", sorted(CASES))
+    def test_against_the_oracle(self, case):
+        system = Level2CPS(self.CASES[case], symbols=SYMBOLS)
+        summaries = Summaries(system, depth=3, limit=4)
+        for word in SAMPLE_WORDS:
+            assert computed(summaries, word) == oracle(system, word), word
+
+    def test_against_the_oracle_on_random_systems(self):
+        rng = random.Random(2026)
+        for _ in range(25):
+            system = random_system(rng)
+            summaries = Summaries(system, depth=3, limit=4)
+            for word in SAMPLE_WORDS:
+                found, said = oracle(system, word), computed(summaries, word)
+                for name, pairs in found.items():
+                    assert pairs <= said[name], (name, word, system.rules)
+
+    def test_raising_the_bound_only_finds_more(self):
+        """The fixpoint is taken over words up to a length, so a longer bound
+        can only turn up runs the shorter one had no room to write down."""
+        rng = random.Random(7)
+        for _ in range(10):
+            system = random_system(rng)
+            shallow = Summaries(system, depth=2, limit=2)
+            deeper = Summaries(system, depth=4, limit=4)
+            for word in SAMPLE_WORDS[:3]:
+                for name, pairs in computed(shallow, word).items():
+                    assert pairs <= computed(deeper, word)[name], name
+
+    def test_a_word_beyond_the_bound_is_refused(self):
+        system = Level2CPS(self.CASES['cloning only'], symbols=SYMBOLS)
+        summaries = Summaries(system, depth=2, limit=2)
+        with pytest.raises(ValueError, match="exceeds"):
+            summaries.of_word(as_path(
+                (Letter('⊥'), Letter('a'), Letter('a'), Letter('a'))))
+
+    def test_the_summary_of_the_paper_s_example(self):
+        """Hague et al.'s system: from state 1 a cloned word can be popped
+        back, and the pushed letter's link is what lets state 2 collapse all
+        the way out."""
+        system = Level2CPS([('0', None, 'Cl', '1', 'clone'),
+                            ('1', None, 'A', '0', 'push a 2'),
+                            ('1', None, 'B', '2', 'push a 2'),
+                            ('2', 'a', 'P', '2', 'pop 1'),
+                            ('2', 'a', 'Co', '0', 'collapse')])
+        summaries = Summaries(system, depth=3, limit=4)
+        for word in SAMPLE_WORDS[:3]:
+            assert computed(summaries, word) == oracle(system, word), word
+
+    def test_summaries_have_a_readable_repr(self):
+        system = Level2CPS(self.CASES['a single pop'], symbols=SYMBOLS)
+        assert 'Summaries' in repr(Summaries(system, depth=2, limit=2))

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -568,3 +568,91 @@ class TestRelationB:
         assert not self.holds(relations, relation,
                               Configuration('0', tall),
                               Configuration('0', Stack((tall.words[0],))))
+
+
+def c_oracle(system, source, target, bound=3000):
+    """``C``: a run to a longer topmost word that never dips below where it
+    started."""
+    if not drops_to(target.stack, source.stack):
+        return False
+    if source == target:
+        return True
+    forbidden = {stack for stack in substacks(source.stack)
+                 if stack != source.stack}
+    seen, frontier, steps = {source}, deque([source]), 0
+    while frontier and steps < bound:
+        configuration = frontier.popleft()
+        steps += 1
+        for _, successor in system.step(configuration):
+            if successor.stack in forbidden:
+                continue                        # never below where it started
+            if successor == target:
+                return True
+            if successor in seen:
+                continue
+            if successor.stack.width > 4 or \
+                    max(map(len, successor.stack.words)) > 6:
+                continue
+            seen.add(successor)
+            frontier.append(successor)
+    return False
+
+
+class TestRelationC:
+    """``C`` — the topmost word gains letters, and the run never dips below
+    where it started. B read backwards, with one asymmetry that matters: a pop
+    is guarded by the letter it removes, but a push by the letter already on
+    top, which is the one *above* the letter written."""
+
+    CASES = {
+        'push and pop back': [('0', None, 'u', '1', 'push a 1'),
+                              ('1', None, 'p', '0', 'pop 1')],
+        'a loop before each push': [('0', None, 'c', '1', 'clone'),
+                                    ('1', None, 'o', '0', 'pop 2'),
+                                    ('0', None, 'u', '2', 'push a 1'),
+                                    ('2', 'a', 'v', '0', 'push b 1')],
+    }
+
+    def relation(self, rules):
+        system = Level2CPS(rules, symbols=SYMBOLS)
+        relations = Relations(system)
+        return system, relations, relations.without_scaffolding(
+            relations.c(), annotated=1)
+
+    def holds(self, relations, relation, source, target):
+        return relation.accepts(convolve_trees(
+            [encode_configuration(source), encode_configuration(target)],
+            frozenset(relations.encoding.alphabet), PAD))
+
+    @pytest.mark.parametrize("case", sorted(CASES))
+    def test_against_the_search(self, case):
+        system, relations, relation = self.relation(self.CASES[case])
+        configurations = [Configuration(state, stack)
+                          for stack in walk_stacks(7, 8)
+                          for state in system.states]
+        for source in configurations:
+            for target in configurations:
+                assert self.holds(relations, relation, source, target) == \
+                    c_oracle(system, source, target), (source, target)
+
+    def test_it_is_reflexive(self):
+        system, relations, relation = self.relation(
+            self.CASES['push and pop back'])
+        for stack in walk_stacks(3, 6):
+            for state in system.states:
+                configuration = Configuration(state, stack)
+                assert self.holds(relations, relation, configuration,
+                                  configuration)
+
+    def test_a_letter_pushed_below_a_separator(self):
+        """The letter goes onto the last word, which the tree hangs under a
+        separator — so the symbol guarding the push is not the separator's but
+        the nearest letter above it, which the annotation knows."""
+        system, relations, relation = self.relation(
+            self.CASES['push and pop back'])
+        word = (Letter('⊥'), Letter('a'))
+        twice = Stack((word, word))
+        longer = Stack((word, word + (Letter('a'),)))
+        assert self.holds(relations, relation,
+                          Configuration('0', twice),
+                          Configuration('1', longer))

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -21,7 +21,10 @@ from autstr.collapsible import (
     Configuration, Letter, Level2CPS, Operation, PAD, Stack, _Encoding,
     encode_configuration, initial_stack,
 )
-from autstr.collapsible_reach import Annotation, Relations, Summaries
+from autstr.collapsible_reach import (
+    Annotation, LabelAutomaton, Relations, Summaries, _Encoding_of,
+    regular_reach,
+)
 from autstr.sparse_tree_automata import Tree, convolve_trees
 
 
@@ -969,3 +972,92 @@ class TestReach:
         assert structure.check('all x.(Reach(x,x))')
         assert structure.check('all x.(all y.(all z.('
                                '(Reach(x,y) & Reach(y,z)) -> Reach(x,z))))')
+
+
+class TestRegularReach:
+    """``Reach_L`` — reachability along runs whose labels a finite automaton
+    accepts. The automaton goes into a product system, whose plain
+    reachability is the answer; what is left is to say that the two
+    configurations are the untagged ones underneath."""
+
+    RULES = [('0', None, 'c', '1', 'clone'),
+             ('1', None, 'o', '0', 'pop 2')]
+
+    def accepts(self, labels, word):
+        current = {labels.initial}
+        for letter in word:
+            current = {target for source, label, target in labels.transitions
+                       if source in current and label == letter}
+        return bool(current & labels.final)
+
+    def search(self, system, source, labels, bound=2000):
+        found, seen = set(), {(source, ())}
+        frontier, steps = deque([(source, ())]), 0
+        while frontier and steps < bound:
+            configuration, word = frontier.popleft()
+            steps += 1
+            if self.accepts(labels, word):
+                found.add(configuration)
+            for label, successor in system.step(configuration):
+                longer = word + (label,)
+                if len(longer) > 3 or (successor, longer) in seen:
+                    continue
+                if successor.stack.width > 3 or \
+                        max(map(len, successor.stack.words)) > 3:
+                    continue
+                seen.add((successor, longer))
+                frontier.append((successor, longer))
+        return found
+
+    def cases(self, system):
+        return {
+            'one clone': LabelAutomaton.of_word(['c']),
+            'a clone then a pop': LabelAutomaton.of_word(['c', 'o']),
+            'anything at all': LabelAutomaton.anything(system.labels),
+            'clones are silent':
+                LabelAutomaton.contracting(system.labels, {'c'}),
+        }
+
+    @pytest.mark.parametrize("case", ['one clone', 'a clone then a pop',
+                                      'anything at all', 'clones are silent'])
+    def test_against_the_search(self, case):
+        system = Level2CPS(self.RULES, symbols=SYMBOLS)
+        labels = self.cases(system)[case]
+        relation = regular_reach(system, labels)
+        alphabet = frozenset(_Encoding_of(system).alphabet)
+        configurations = [Configuration(state, stack)
+                          for stack in walk_stacks(6, 4, width=2, height=2)
+                          for state in system.states]
+        for source in configurations:
+            found = self.search(system, source, labels)
+            for target in configurations:
+                got = relation.accepts(convolve_trees(
+                    [encode_configuration(source),
+                     encode_configuration(target)], alphabet, PAD))
+                assert got == (target in found), (case, source, target)
+
+    def test_anything_at_all_is_plain_reachability(self):
+        """The label automaton that accepts everything gives back the
+        relation `Relations.reach` builds on its own."""
+        from autstr.utils.tree_automata_tools import equivalent
+        system = Level2CPS(self.RULES, symbols=SYMBOLS)
+        constrained = regular_reach(
+            system, LabelAutomaton.anything(system.labels))
+        assert equivalent(constrained, Relations(system).reach())
+
+    def test_the_graph_declares_reachability(self):
+        """It is in the signature from the start, and built when asked for."""
+        system = Level2CPS(self.RULES, symbols=SYMBOLS)
+        graph = system.configuration_graph()
+        assert 'Reach' in graph.get_relation_symbols()
+        assert graph.check('all x.(Reach(x,x))')
+        assert graph.check('all x.(all y.(all z.('
+                           '(Reach(x,y) & Reach(y,z)) -> Reach(x,z))))')
+        assert graph.check('all x.(all y.(E(x,y) -> Reach(x,y)))')
+
+    def test_the_graph_takes_a_label_constraint(self):
+        system = Level2CPS(self.RULES, symbols=SYMBOLS)
+        graph = system.configuration_graph()
+        graph.reach_along('Cloned', LabelAutomaton.of_word(['c']))
+        # one clone is one step, so this is the c-labelled edge relation
+        assert graph.check('all x.(all y.(Cloned(x,y) <-> Edgec(x,y)))')

--- a/tests/test_collapsible_reach.py
+++ b/tests/test_collapsible_reach.py
@@ -825,14 +825,14 @@ def d_oracle(system, source, target, bound=3000):
 
 
 class TestRelationD:
-    """``D`` — the stack grows. **Not correct yet.**
+    """``D`` — the stack grows, and the run never dips below where it started.
 
     Kartzow's Cor. 4.10 walks the milestones of the stack being built, which
-    the encoding puts in traversal order. What this does not yet handle are
-    the *generalised* milestones: between one word and the next the run passes
-    through the previous word cloned whole, and only then pops it down to
-    where the two words part. Getting that wrong shows up in both directions,
-    and the two cases below are kept as a record of it.
+    the encoding puts in traversal order, so the run only ever moves forward
+    through the tree. Measuring that walk gives three moves: a push to a left
+    child, a clone to a right child, and an ascent that clones at the *deepest*
+    node reached and then pops one letter per level, each node giving up its
+    own. A separator carries no letter, so it pops nothing.
     """
 
     CLONE_ONLY = [('0', None, 'c', '1', 'clone')]
@@ -865,9 +865,6 @@ class TestRelationD:
                 assert self.holds(relations, relation, configuration,
                                   configuration)
 
-    @pytest.mark.xfail(reason="the generalised milestones are not handled: "
-                              "the run clones the whole word before popping "
-                              "it down to where the two words part")
     def test_a_word_shorter_than_its_clone_needs_pops(self):
         """The system can only clone and pop words, never letters — so the
         second word cannot be shorter than the first."""
@@ -878,3 +875,97 @@ class TestRelationD:
             relations, relation,
             Configuration('0', Stack((long_word,))),
             Configuration('1', Stack((long_word, short_word))))
+        # the cloned copy itself, however, is one step away
+        assert self.holds(relations, relation,
+                          Configuration('0', Stack((long_word,))),
+                          Configuration('1', Stack((long_word, long_word))))
+
+    @pytest.mark.parametrize("case", ['clone only', 'clone, pop, push'])
+    def test_against_the_search(self, case):
+        rules = {'clone only': self.CLONE_ONLY,
+                 'clone, pop, push': [('0', None, 'c', '1', 'clone'),
+                                      ('1', 'a', 'p', '2', 'pop 1'),
+                                      ('2', None, 'u', '0', 'push b 1'),
+                                      ('0', None, 'k', '0', 'clone')]}[case]
+        system, relations, relation = self.relation(rules)
+        # a random walk alone rarely produces two stacks that are actually
+        # related, so grow the sample from each stack's clone and pops
+        stacks = walk_stacks(5, 6, width=2, height=3)
+        related = list(stacks)
+        for stack in stacks:
+            related += [stack.clone()] + \
+                ([stack.pop2()] if stack.pop2() else []) + \
+                ([stack.clone().pop1()] if stack.clone().pop1() else [])
+        seen, unique = set(), []
+        for stack in related:
+            if repr(stack) not in seen and stack.width <= 3:
+                seen.add(repr(stack))
+                unique.append(stack)
+        configurations = [Configuration(state, stack) for stack in unique
+                          for state in system.states]
+        for source in configurations:
+            for target in configurations:
+                assert self.holds(relations, relation, source, target) == \
+                    d_oracle(system, source, target), (source, target)
+
+
+class TestReach:
+    """Reachability itself: the composition of the four.
+
+    Every run splits into words coming off, letters coming off, letters going
+    on and words going on, and all four relations are reflexive — so the
+    composition excludes nothing, and it is a first-order formula rather than
+    an automaton of its own.
+    """
+
+    CASES = {
+        'clone and pop back': [('0', None, 'c', '1', 'clone'),
+                               ('1', None, 'o', '0', 'pop 2')],
+        'push and pop letters': [('0', None, 'u', '1', 'push a 1'),
+                                 ('1', 'a', 'p', '0', 'pop 1')],
+    }
+
+    def search(self, system, source, bound=4000):
+        seen, frontier, steps = {source}, deque([source]), 0
+        while frontier and steps < bound:
+            configuration = frontier.popleft()
+            steps += 1
+            for _, successor in system.step(configuration):
+                if successor in seen:
+                    continue
+                if successor.stack.width > 3 or \
+                        max(map(len, successor.stack.words)) > 4:
+                    continue
+                seen.add(successor)
+                frontier.append(successor)
+        return seen
+
+    @pytest.mark.parametrize("case", sorted(CASES))
+    def test_against_the_search(self, case):
+        system = Level2CPS(self.CASES[case], symbols=SYMBOLS)
+        relations = Relations(system)
+        reach = relations.reach()
+        alphabet = frozenset(relations.encoding.alphabet)
+        configurations = [Configuration(state, stack)
+                          for stack in walk_stacks(4, 5, width=2, height=3)
+                          for state in system.states]
+        for source in configurations:
+            found = self.search(system, source)
+            for target in configurations:
+                got = reach.accepts(convolve_trees(
+                    [encode_configuration(source),
+                     encode_configuration(target)], alphabet, PAD))
+                assert got == (target in found), (source, target)
+
+    def test_it_is_reflexive_and_transitive(self):
+        """Two first-order questions about reachability — which is the whole
+        point of having it as a relation of the structure."""
+        from autstr.tree_presentations import TreeAutomaticPresentation
+        system = Level2CPS(self.CASES['clone and pop back'], symbols=SYMBOLS)
+        relations = Relations(system)
+        structure = TreeAutomaticPresentation(
+            {'U': relations.encoding.universe(),
+             'Reach': relations.reach()}, padding_symbol=PAD)
+        assert structure.check('all x.(Reach(x,x))')
+        assert structure.check('all x.(all y.(all z.('
+                               '(Reach(x,y) & Reach(y,z)) -> Reach(x,z))))')

--- a/tests/test_tree_tools.py
+++ b/tests/test_tree_tools.py
@@ -10,7 +10,7 @@ from autstr.sparse_tree_automata import (
 from autstr.utils.misc import encode_symbol
 from autstr.utils.tree_automata_tools import (
     attach_padding, domain_within, equivalent, expand, fold_tapes, minimize,
-    partial_tree_automaton, project, tree_order,
+    partial_tree_automaton, project, restrict_alphabet, tree_order,
 )
 from test_tree_automata import RefDTA, random_sta, random_tree
 
@@ -612,3 +612,35 @@ class TestDomainWithin:
     def test_a_negative_depth_is_refused(self):
         with pytest.raises(ValueError, match="depth"):
             domain_within(self.ALPHABET, '*', -1)
+
+
+class TestRestrictAlphabet:
+    """Reading an automaton over fewer letters keeps what it does on the ones
+    that remain — which is what a construction needs once an annotation it was
+    built to read has been quantified away."""
+
+    WIDE = {'*', 'a', 'b', 'c'}
+    NARROW = {'*', 'a', 'b'}
+
+    def automaton(self, rng, alphabet):
+        names = ['s0', 's1', 's2']
+        table = {(rng.choice([None] + names), rng.choice([None] + names),
+                  (rng.choice(sorted(alphabet)),)): rng.choice(names)
+                 for _ in range(rng.randint(3, 14))}
+        return partial_tree_automaton(alphabet, 1, table,
+                                      set(rng.sample(names, 2)))
+
+    def test_the_language_over_the_kept_letters_is_unchanged(self):
+        rng = random.Random(3)
+        sample = [random_labelled_tree(rng, ['a', 'b']) for _ in range(40)]
+        for _ in range(20):
+            wide = self.automaton(rng, self.WIDE)
+            narrow = restrict_alphabet(wide, self.NARROW)
+            assert narrow.base_alphabet_frozen == frozenset(self.NARROW)
+            for tree in sample:
+                assert narrow.accepts(tree) == wide.accepts(tree), tree
+
+    def test_widening_is_refused(self):
+        rng = random.Random(4)
+        with pytest.raises(ValueError, match="no letter"):
+            restrict_alphabet(self.automaton(rng, self.NARROW), self.WIDE)


### PR DESCRIPTION
Level 2 collapsible pushdown graphs got their configuration graph in #42. This
adds the relation that made them worth putting on the tree engine in the first
place: **reachability**. A first-order formula over one of these graphs may now
ask about runs of any length -- the question `autstr.turing` cannot answer, and
the reason the encoding is a tree and not a word.

Following Kartzow, [*The Model Checking Problem for Prefix Replacement Systems
and Collapsible Pushdown Graphs*](https://arxiv.org/abs/1303.2453) (§4-5,
appendices A-D).

## Reach is a formula, not an automaton

The construction's shape is a decomposition (Remark 4.4): every run between two
configurations factors into four stages, each **reflexive**, so

    Reach(x,y) = exists d,e,f. A(x,d) & B(d,e) & C(e,f) & D(f,y)

`A` drops whole words, `B` drops letters off the topmost word, `C` pushes
letters back on, `D` grows words again. Four automata over the encoding trees,
then one formula -- no fifth automaton, and no fixpoint over trees.

## The word layer

Underneath all four is a fact about the machine rather than the encoding: what
returns and loops a stack admits depends only on its **topmost word**. So
`Summaries` computes, per word, the four relations on control states (`ret`,
`hloop`, `lloop`, `oneloop`) by saturation, and merges words with equal
summaries into automaton states.

Merging needs a **stability** criterion, not a depth bound. A word at the
fixpoint's edge has its extensions pinned empty, so it disagrees with an
interior word of the same summary -- which looks like the theory failing and is
only the bound talking. Summaries only grow, so a value that survived two
consecutive bounds is the truth. The merged automaton must also be *closed*:
every reachable summary needs a transition for every letter, all witnessed by
stable words. Short of that a real word has no summary, its tree cannot be
annotated, and that surfaces as a relation quietly missing edges.

## Nondeterministic guesses on deterministic tapes

Kartzow's tree automata guess, at each node, the states in which the milestone
that node represents is entered and left. `SparseTreeAutomaton` is
deterministic bottom-up, so the guesses go on **tapes**: an `Annotation` tape
carrying each node's summary (checked locally against the parent's), plus a
guess tape per relation, then `project` quantifies them away and
`restrict_alphabet` narrows back to the configuration alphabet. The exponential
moves into tape width and into `project`'s subset construction, where
`max_states` already turns a blowup into a clean error. It is the move MONA
makes.

## Reach_L, by transforming the system

Kartzow builds the label automaton into the reachability automaton; here it
goes into a **product system**, whose ordinary reachability is the answer,
related back to plain configurations by a root-relabelling:

    Reach_L(x,y) = exists u,v. Tag_p0(x,u) & Reach(u,v) & (or_f Tag_f(y,v))

Both kinds of configuration share a structure for the length of that formula --
hence `_Encoding`'s `extra_states`. An epsilon-contraction then needs nothing
new: it is any number of silent labels followed by one other.

## Using it

`Reach` is in the signature from the start and built the first time a query
mentions it. It is exponential in the number of control states, so that
deferral *is* the opt-out -- no build flag:

```python
graph = Level2CPG(system)
'Reach' in graph.get_relation_symbols()      # True, nothing built yet
graph.query('exists y. Reach(x, y) & ...')   # builds it here
graph.reach_along('Silent', LabelAutomaton.contracting(['eps'], ['a']))
```

The paper's own example builds in ~16s at 663 states. This will not scale to
large systems and is not meant to.

## Checking

Against breadth-first search, and against a search that tracks the labels it
reads on four constraints (an exact word, a two-letter word, everything --
shown `equivalent` to plain `Reach` -- and the contraction shape).

The check that mattered most needed no oracle at all: **is the built relation
transitive?** A sweep over small stacks reported "0 disagreements" on 13
systems while `D` was thoroughly broken, because a random walk almost never
produces two stacks that are actually related. Transitivity is a global
question over all configurations, and it found the last bug on configurations
no sweep had reached. The suite asks reflexivity, transitivity, and containment
of the edge relation.

100 new tests (55 reachability, 45 collapsible). Full suite: 830 passed, 5
skipped.

Also carried along: a docstring fix for #43 that landed on that branch after it
merged, and `restrict_alphabet` in `tree_automata_tools`.

Generated with [Claude Code](https://claude.com/claude-code)
